### PR TITLE
Fix issue 33 (response missing after going to a different page)

### DIFF
--- a/ubcpi/test/test_lms.py
+++ b/ubcpi/test/test_lms.py
@@ -61,6 +61,12 @@ class LmsTest(XBlockHandlerTestCaseMixin, TestCase):
         # check the stats that we have 1 answer
         self.assertEqual(xblock.stats['original'][data['post1']['q']], 1)
 
+        # Check the data is persisted
+        persisted = xblock.get_persisted_data()
+        self.assertEquals(persisted['answer_original'], 0)
+        self.assertFalse( 'correct_answer' in persisted )
+
+
         # submit revised answer
         resp = self.request(xblock, 'submit_answer', json.dumps(data['post2']), response_format='json')
         self.assertEqual(resp, data['expect2'])
@@ -75,6 +81,11 @@ class LmsTest(XBlockHandlerTestCaseMixin, TestCase):
         # check the stats that we have 1 answer
         self.assertEqual(xblock.stats['original'][data['post1']['q']], 1)
         self.assertEqual(xblock.stats['revised'][data['post2']['q']], 1)
+
+        # Check we now have all the persisted data we should have
+        persisted = xblock.get_persisted_data()
+        self.assertEquals(persisted['answer_original'], 0)
+        self.assertTrue( 'correct_answer' in persisted )
 
     @file_data('data/submit_answer_errors.json')
     @scenario(os.path.join(os.path.dirname(__file__), 'data/basic_scenario.xml'), user_id='Bob')

--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -509,6 +509,14 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin):
         # convert key into integers as json.dump and json.load convert integer dictionary key into string
         self.sys_selected_answers = {int(k): v for k, v in self.sys_selected_answers.items()}
         self.record_response(data['q'], data['rationale'], data['status'])
+
+        return self.get_persisted_data()
+
+    def get_persisted_data(self):
+        """
+        Formats a usable dict based on what data the user has persisted
+        Adds the other answers and correct answer/rationale when needed
+        """
         answers = self.get_answers_for_student()
         ret = {
             "answer_original": answers.get_vote(0),
@@ -526,6 +534,13 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin):
             ret['correct_rationale'] = self.correct_rationale
 
         return ret
+
+    @XBlock.json_handler
+    def get_data(self,data,suffix=''):
+        """
+        Retrieve persisted date from backend for current user
+        """
+        return self.get_persisted_data()
 
     def get_answers_for_student(self):
         """


### PR DESCRIPTION
This adds a new `get_data` XBlock JSON Handler which returns the persisted data saved by the student. This allows us to verify the persisted data if the student moves back and forth through the steps in the same or different instances of the XBlock.

Also adds JS and Python unit tests to cover this functionality.

Fix #33