### PR TITLE
Fix display of graphs on mobile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ after_success:
   - "coveralls-lcov -v -n build/coverage/report-lcov/lcov.info > js-coverage.json"
   - "coveralls --merge=js-coverage.json"
 
-branches:
-    only:
-      - master
+#branches:
+#    only:
+#      - master

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
     plugins: [
       'karma-coverage',
       'karma-jasmine',
-	  'karma-jasmine-jquery',
+      'karma-jasmine-jquery',
       'karma-chrome-launcher',
       'karma-firefox-launcher',
       'karma-phantomjs-launcher',
@@ -24,7 +24,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      '../../../node_modules/jquery/tmp/jquery.js',
+      '../../../node_modules/jquery/dist/jquery.js',
       '../../../node_modules/angular/angular.js',
       '../../../node_modules/angular-messages/angular-messages.js',
       '../../../node_modules/angular-sanitize/angular-sanitize.js',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cucumber": "^0.5.2",
     "d3": "~3.3",
     "jasmine-core": "^2.3.4",
-    "jquery": "~1.7",
+    "jquery": "~2.2",
     "karma": "^0.13",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.4.2",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@
 
 coverage==3.7.1
 ddt==1.0.0
-django-nose==1.3
+django-nose==1.4.1
 mock==1.3.0
 pep8==1.5.7
 pylint<1.0

--- a/ubcpi/static/js/src/d3-pibar.js
+++ b/ubcpi/static/js/src/d3-pibar.js
@@ -41,9 +41,11 @@ d3.custom.barChart = function(scope) {
             var height = chartHeight - margin.top - margin.bottom;
 
             var svg = d3.select(this)
+                .classed("svg-container", true)
                 .append("svg")
-                .attr("width", chartWidth)
-                .attr("height", chartHeight);
+                .attr("preserveAspectRatio", "xMaxYMax meet")
+                .attr("viewBox", "0 0 800 250")
+                .classed("svg-content-responsive", true);
 
             var x = d3.scale.ordinal()
                 .rangeRoundBands([0, width], 0.1);
@@ -152,3 +154,4 @@ d3.custom.barChart = function(scope) {
 
     return chart;
 };
+


### PR DESCRIPTION
Graphs are now responsive and resize appropriately for smaller screens;
tested in Device Mode with Responsive Mode using Chrome Version
53.0.2785.116 (64-bit) on Ubuntu 16.04.