### PR TITLE
Fix rationale bug on select of no correct answer

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
     plugins: [
       'karma-coverage',
       'karma-jasmine',
-	  'karma-jasmine-jquery',
+      'karma-jasmine-jquery',
       'karma-chrome-launcher',
       'karma-firefox-launcher',
       'karma-phantomjs-launcher',
@@ -24,7 +24,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      '../../../node_modules/jquery/tmp/jquery.js',
+      '../../../node_modules/jquery/dist/jquery.js',
       '../../../node_modules/angular/angular.js',
       '../../../node_modules/angular-messages/angular-messages.js',
       '../../../node_modules/angular-sanitize/angular-sanitize.js',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cucumber": "^0.5.2",
     "d3": "~3.3",
     "jasmine-core": "^2.3.4",
-    "jquery": "~1.7",
+    "jquery": "~2.2",
     "karma": "^0.13",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.4.2",

--- a/ubcpi/answer_pool.py
+++ b/ubcpi/answer_pool.py
@@ -119,9 +119,10 @@ def validate_seeded_answers_simple(answers, options, algo):
     index = 1
     for option in options:
         key = option.get('text') + option.get('image_url') if option.get('image_url') else option.get('text')
-        if seen_options.get(key, 0) == 0:
-            missing_options.append('Option ' + str(index))
-        index += 1
+        if option.get('text') != 'No correct answer':
+            if seen_options.get(key, 0) == 0:
+                missing_options.append('Option ' + str(index))
+            index += 1
 
     if missing_options:
         return {'seed_error': 'Missing option seed(s): ' + ', '.join(missing_options)}

--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -152,7 +152,8 @@
                                 <p class="ubcpi-solution-your-final-answer">
                                     Your final answer:
                                     <span ng-if="rc.correct_answer === rc.answer_revised" class="ubcpi-initial-option-text ubcpi-correct-final-answer ubcpi-show-correct">{{options[rc.answer_revised].text}} </span>
-                                    <span ng-if="rc.correct_answer !== rc.answer_revised" class="ubcpi-initial-option-text ubcpi-incorrect-final-answer ubcpi-show-incorrect">{{options[rc.answer_revised].text}} </span>
+                                    <span ng-if="rc.correct_answer === rc.options.length" class="ubcpi-initial-option-text ubcpi-correct-final-answer ubcpi-show-correct">{{options[rc.answer_revised].text}} </span>
+                                    <span ng-if="rc.correct_answer !== rc.answer_revised && rc.correct_answer != rc.options.length" class="ubcpi-initial-option-text ubcpi-incorrect-final-answer ubcpi-show-incorrect">{{options[rc.answer_revised].text}} </span>
                                     <span class="ubcpi-initial-option-num">(Option {{rc.answer_revised + 1}})</span>
                                 </p>
                                 <span class="sr">Student Rationale</span><i aria-hidden="true" class="icon fa fa-user"></i><span class="ubcpi-solution-your-final-rationale ubcpi-solution-rationales">"{{rc.rationale_revised}}"</span>

--- a/ubcpi/static/html/ubcpi_edit.html
+++ b/ubcpi/static/html/ubcpi_edit.html
@@ -108,7 +108,7 @@
                             <label class="label setting-label pi-setting-label" for="pi-option-correct" aria-describedby="pi-option-correct-tip">Correct Answer</label>
                             <span id="pi-option-correct-tip" class="tip setting-help">Choose the answer you consider correct.</span>
                         </div>
-                        <select name="pi-option-correct" id="pi-option-correct" ng-model="esc.data.correct_answer" ng-model-options="{ debounce: 500 }" ng-options="esc.data.options.indexOf(option) as ('Option ' + (esc.data.options.indexOf(option) +1) ) for option in esc.data.options" required></select>
+                        <select name="pi-option-correct" id="pi-option-correct" ng-model="esc.data.correct_answer" ng-model-options="{ debounce: 500 }" ng-options="esc.makeOptions().indexOf(opt) as opt for opt in esc.makeOptions()" required></select>
                     </div>
                     <div class="wrapper-comp-setting pi-wrapper-comp-setting">
                         <div class="pi-label-and-hint">

--- a/ubcpi/static/js/spec/ubcpi_edit_spec.js
+++ b/ubcpi/static/js/spec/ubcpi_edit_spec.js
@@ -264,6 +264,12 @@ describe('UBCPI_Edit module', function () {
             );
         });
 
+        it('should add "No correct answer" option to a return options array when makeOptions is called', function() {
+            var options = controller.makeOptions();
+            expect(controller.data.options.length+1).toBe(options.length);
+            expect(options[options.length-1]).toEqual("No correct answer");
+        });
+
         it('should fail silently when invalid index is give to delete_option', function() {
             controller.delete_option(5);
             expect(controller.data.options.length).toBe(3);

--- a/ubcpi/static/js/src/ubcpi.js
+++ b/ubcpi/static/js/src/ubcpi.js
@@ -202,6 +202,7 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies'])
                 self.answer = data.answer_revised || data.answer_original;
                 self.rationale = data.rationale_revised || data.rationale_original;
                 self.weight = data.weight;
+                self.options = data.options;
             }
 
         }]);

--- a/ubcpi/static/js/src/ubcpi_edit.js
+++ b/ubcpi/static/js/src/ubcpi_edit.js
@@ -145,7 +145,7 @@ angular.module("ubcpi_edit", ['ngMessages', 'ngSanitize', 'ngCookies'])
 
             self.submit = function() {
                 notify('save', {state: 'start', message: "Saving"});
-                if(data.correct_answer == data.options.length)
+                if(self.data.correct_answer == data.options.length)
                     self.data.correct_rationale.text = "n/a";
 
                 return studioBackendService.submit(self.data).catch(function(errors) {

--- a/ubcpi/static/js/src/ubcpi_edit.js
+++ b/ubcpi/static/js/src/ubcpi_edit.js
@@ -59,6 +59,20 @@ angular.module("ubcpi_edit", ['ngMessages', 'ngSanitize', 'ngCookies'])
         function ($scope, studioBackendService, notify, $rootScope) {
             var self = this;
             var data = $scope.config.data;
+
+            self.makeOptions = function() {
+                var options = [];
+                for (var i = 0; i < data.options.length + 1; i++) {
+                    if(i==(data.options.length))
+                        options.push("No correct answer");
+                    else {
+                        var option = i+1;
+                        options.push("Option " + option);
+                    }
+                }
+                return options;
+            };
+
             self.algos = data.algos;
             self.data = {};
             self.data.display_name = data.display_name;
@@ -131,6 +145,8 @@ angular.module("ubcpi_edit", ['ngMessages', 'ngSanitize', 'ngCookies'])
 
             self.submit = function() {
                 notify('save', {state: 'start', message: "Saving"});
+                if(data.correct_answer == data.options.length)
+                    self.data.correct_rationale.text = "n/a";
 
                 return studioBackendService.submit(self.data).catch(function(errors) {
                     notify('error', {


### PR DESCRIPTION
The rationale text was not correctly set when "No correct answer" was selected for the first setting of a correct answer for a question.