### PR TITLE
Implement round of final changes for 0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ One of the key features in the success of peer instruction in enhancing student 
 
 ## Basic workflow
 
-1. In Studio, course creator creates a new advanced problem of type Peer Instruction, configures and publishes
+1. In Studio, course creator creates a new advanced problem of type Peer Rationale Reflection, configures and publishes
 2. In the LMS, (following some content presentation) the student is presented the question, answer options and text box to complete their rationale for their answer.
 3. Following submit, the student is presented with a range of alternative student answers and rationales (This is as an alternative to small group discussion)
 4. Students reflect on the answers presented, then modify their own answer and rationale and submit a final answer

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         ]
     },
     package_data=package_data("ubcpi", ["static", "public", "translations"]),
-    keywords=['edx', 'peer instruction', 'ubc'],
+    keywords=['edx', 'peer rationale reflection', 'ubc'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Plugins",

--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -45,7 +45,7 @@
 
             </div><!-- .others-responses -->
 
-            <span id="answer" ng-if="rc.status() == rc.ALL_STATUS.NEW && user_role == 'student'">
+            <span id="answer" ng-if="rc.status() == rc.ALL_STATUS.NEW">
 
                 <ul style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;text-transform:uppercase;">
                   <li style="display:inline-block;width:30%;text-align:center;font-weight:bold;color:#333;padding-top:.3em"><i class="fa fa-arrow-circle-down" style="font-size:1.4em;"></i></span><br>Answer</li>
@@ -90,7 +90,6 @@
                 <p class="ubc-pi-next">
                     <span id="ubcpi-next-inline-hints">
                         <span class="inline-hint" ng-if="rc.status() == rc.ALL_STATUS.NEW"><span class="sr">Hint</span><i aria-hidden="true" class="icon fa fa-info-circle"></i> In the next step you will be shown a selection of other responses which may help you refine your answer.</span>
-                        <span class="inline-hint" ng-if="rc.status() == rc.ALL_STATUS.ANSWERED"><span class="sr">Hint</span><i aria-hidden="true" class="icon fa fa-info-circle"></i> After submitting your final answer, you will see the correct answer for this question.</span>
                     </span>
                 </p>
 
@@ -178,7 +177,9 @@
                             <li class="ubcpi-initial">
                                 <p class="ubcpi-solution-your-initial-answer">
                                     Your initial answer:
-                                    <span class="ubcpi-initial-option-text">{{options[rc.answer_original].text}} </span>
+                                    <span ng-if="rc.correct_answer === rc.answer_original" class="ubcpi-initial-option-text ubcpi-correct-final-answer ubcpi-show-correct">{{options[rc.answer_original].text}} </span>
+                                    <span ng-if="rc.correct_answer !== rc.answer_original && rc.correct_answer !== options.length" class="ubcpi-initial-option-text ubcpi-incorrect-final-answer ubcpi-show-incorrect">{{options[rc.answer_original].text}} </span>
+                                    <span ng-if="rc.correct_answer === options.length" class="ubcpi-initial-option-text ubcpi-correct-final-answer">{{options[rc.answer_original].text}} </span>
                                     <span class="ubcpi-initial-option-num">(Option {{rc.answer_original + 1}})</span>
                                 </p>
                                 <span class="sr">Student Rationale</span><i aria-hidden="true" class="icon fa fa-user"></i><span class="ubcpi-solution-your-initial-rationale ubcpi-solution-rationales">"{{rc.rationale_original}}"</span>
@@ -226,13 +227,11 @@
                 <div class="original-answers results-container choicegroup">
 
                     <pi-barchart options="options" stats="rc.stats.original" correct="rc.correct_answer" role="user_role"></pi-barchart>
-                    <p class="ubcpi-chart-label">Original Answer</p>
                 </div><!-- .original-answers -->
 
                 <h4>Final Answer Selection</h4>
                 <div class="revised-answers results-container choicegroup">
                     <pi-barchart options="options" stats="rc.stats.revised" correct="rc.correct_answer" role="user_role"></pi-barchart>
-                    <p class="ubcpi-chart-label">Revised Answer</p>
                 </div><!-- .revised-answers -->
 
             </div>

--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -9,12 +9,14 @@
             <div class="question-weight" ng-if="weight == 1">&nbsp;({{weight}} point possible)</div>
             <div class="question-weight" ng-if="weight > 1">&nbsp;({{weight}} points possible)</div>
 
+            <div style="padding: .5em; margin-bottom: 0px; background: #ddd;"><h2 id="pi-question-h" class="question-text" style="margin-bottom:0">QUESTION</h2></div>
+            <div style="margin: 0 0 1.5em 0; padding: 1em; background: #f8f8f8;">
             <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'above' && question_text.image_url" />
 
             <span aria-labelledby="pi-question-h" id="question-text" ng-bind-html="question_text.text" ng-if="question_text.text"></span>
 
             <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'below' && question_text.image_url" />
-
+            </div>
             <span id="reflect" ng-if="rc.status() == rc.ALL_STATUS.ANSWERED">
                 <ul style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;text-transform:uppercase;">
                     <li style="display:inline-block;width:30%;text-align:center;color:#aaa;padding-top:.3em"><i class="fa fa-check-circle" style="font-size:1.4em;"></i></span><br>Answer</li>
@@ -130,19 +132,22 @@
 
         <div class="correct-revised-chart" data-ng-if="rc.status() == rc.ALL_STATUS.REVISED" data-ng-init="rc.getStats()">
 
-            <h2 id="pi-question-h" class="question-text">Question</h2>
-
+            <h2 id="pi-question-h" class="question-text">{{display_name}}</h2>
             <div class="question-weight" ng-if-"rc.weight < 1"></div>
 
             <div class="question-weight" ng-if="rc.weight == 1">({{weight}} point possible)</div>
 
             <div class="question-weight" ng-if="rc.weight > 1">({{weight}} points possible)</div>
 
+            <div style="padding: .5em; margin-bottom: 0px; background: #ddd;"><h2 id="pi-question-h" class="question-text" style="margin-bottom:0">QUESTION</h2></div>
+            <div style="margin: 0 0 1.5em 0; padding: 1em; background: #f8f8f8;">
+
             <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'above' && question_text.image_url" />
 
             <span aria-labelledby="pi-question-h" id="question-text" ng-bind-html="question_text.text" ng-if="question_text.text"></span>
 
             <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'below' && question_text.image_url" />
+            </div>
 
             <span id="test" ng-if="rc.status() == rc.ALL_STATUS.REVISED">
                 <ul style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;text-transform:uppercase;">

--- a/ubcpi/static/html/ubcpi_edit.html
+++ b/ubcpi/static/html/ubcpi_edit.html
@@ -8,8 +8,8 @@
 
                 <li class="ubcpi-pi-intro">
                     <p><strong>Peer Instruction</strong></p>
-                    <p>Peer instruction problems give learners an opportunity for interactive engagement while they answer a multiple choice question. Learners complete these problems in three steps.</p>
-                    <p>First, the learner answers a multiple choice question and provides a rationale for the answer. Next, the learner sees the rationale provided by another learner for each of the other possible answers. After assessing this input, the learner can make revisions and resubmit an answer and rationale. Finally, the learner sees the correct answer and the rationale that you provide for it.</p>
+                    <p>Peer instruction problems give learners an opportunity for interactive engagement while they answer a multiple choice question that may or may not have a correct answer. Learners complete these problems in three steps.</p>
+                    <p>First, the learner answers a multiple choice question and provides an explanation for the answer. Next, the learner sees the answers and explanations provided by other learners. After assessing this input, the learner can make revisions and resubmit an answer and explanation. Finally, the learner sees the correct answer, if supplied, and any explanation that you provide for it.</p>
                 </li>
 
                 <li class="field comp-setting-entry is-set">
@@ -106,7 +106,7 @@
                     <div class="wrapper-comp-setting pi-wrapper-comp-setting">
                         <div class="pi-label-and-hint">
                             <label class="label setting-label pi-setting-label" for="pi-option-correct" aria-describedby="pi-option-correct-tip">Correct Answer <font color="red">*</font></label>
-                            <span id="pi-option-correct-tip" class="tip setting-help">Choose the answer you consider correct.</span>
+                            <span id="pi-option-correct-tip" class="tip setting-help">Choose the answer you consider correct, or select "n/a" if there is no correct answer.</span>
                         </div>
                         <select name="pi-option-correct" id="pi-option-correct" ng-model="esc.data.correct_answer" ng-model-options="{ debounce: 500 }" ng-options="esc.makeOptions().indexOf(opt) as opt for opt in esc.makeOptions()" required></select>
                     </div>

--- a/ubcpi/static/html/ubcpi_edit.html
+++ b/ubcpi/static/html/ubcpi_edit.html
@@ -7,9 +7,9 @@
             <ul class="list-input settings-list" id="pi-line-items">
 
                 <li class="ubcpi-pi-intro">
-                    <p><strong>Peer Instruction</strong></p>
-                    <p>Peer instruction problems give learners an opportunity for interactive engagement while they answer a multiple choice question that may or may not have a correct answer. Learners complete these problems in three steps.</p>
-                    <p>First, the learner answers a multiple choice question and provides an explanation for the answer. Next, the learner sees the answers and explanations provided by other learners. After assessing this input, the learner can make revisions and resubmit an answer and explanation. Finally, the learner sees the correct answer, if supplied, and any explanation that you provide for it.</p>
+                    <p><strong>Peer Rationale Reflection</strong></p>
+                    <p>Peer-based reflection problems give learners more interactive engagement while they complete a multiple choice question that may or may not have a correct answer. The tool supports deeper consideration of the learner’s understanding of a concept and the correctness (if applicable) of an initial answer. Learners complete these problems in three steps.</p>
+                    <p>First, the learner answers a multiple choice question and provides an explanation for the answer. Next, the learner sees answers and explanations submitted by other learners. After reflecting on these peer responses, the learner can make revisions and submit a final answer and explanation. Finally, the learner sees the correct answer, if supplied, and any explanation that you provided for it.</p>
                 </li>
 
                 <li class="field comp-setting-entry is-set">

--- a/ubcpi/static/js/features/support/default_pi.json
+++ b/ubcpi/static/js/features/support/default_pi.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Peer Instruction",
+  "display_name": "Peer Rationale Reflection",
   "question_text": {
     "text": "What is the answer to life, the universe and everything?",
     "image_show_fields": 0,

--- a/ubcpi/static/js/spec/ubcpi_edit_spec.js
+++ b/ubcpi/static/js/spec/ubcpi_edit_spec.js
@@ -158,7 +158,7 @@ describe('UBCPI_Edit module', function () {
                 "correct_rationale": {"text": "correct rationale"},
                 "image_position_locations": {"below": "Appears below", "above": "Appears above"},
                 "rationale_size": {"max": 32000, "min": 1},
-                "display_name": "Peer Instruction",
+                "display_name": "Peer Rationale Reflection",
                 "algo": {"num_responses": "#", "name": "simple"},
                 "algos": {
                     "simple": "System will select one of each option to present to the students.",

--- a/ubcpi/static/xml/basic_scenario.xml
+++ b/ubcpi/static/xml/basic_scenario.xml
@@ -1,5 +1,5 @@
 <ubcpi rationale_size_min="1" rationale_size_max="32000" algorithm="simple" num_responses="#">
-    <display_name>Sample Peer Instruction</display_name>
+    <display_name>Sample Peer Rationale Reflection</display_name>
     <question>
         <text>This is the question text</text>
     </question>

--- a/ubcpi/test/data/basic_scenario.xml
+++ b/ubcpi/test/data/basic_scenario.xml
@@ -1,5 +1,5 @@
 <ubcpi rationale_size_min="1" rationale_size_max="32000" algorithm="simple" num_responses="#">
-    <display_name>Sample Peer Instruction</display_name>
+    <display_name>Sample Peer Rationale Reflection</display_name>
     <question>
         <image position="below" alt="This is a image" show_fields="0">/static/test.jpg</image>
         <text>This is the question text</text>

--- a/ubcpi/test/data/parse_from_xml.json
+++ b/ubcpi/test/data/parse_from_xml.json
@@ -2,7 +2,7 @@
   "basic": {
     "xml": [
       "<ubcpi rationale_size_min=\"1\" rationale_size_max=\"32000\" algorithm=\"simple\" num_responses=\"#\">",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Sample Peer Rationale Reflection</display_name>",
         "<question>",
             "<text>This is the question text</text>",
             "<image position=\"below\" alt=\"This is a image\" show_fields=\"0\">/static/test.jpg</image>",
@@ -24,7 +24,7 @@
       "</ubcpi>"
     ],
     "expect": {
-      "display_name": "Sample Peer Instruction",
+      "display_name": "Sample Peer Rationale Reflection",
       "question_text": {
         "image_url": "/static/test.jpg",
         "image_position": "below",
@@ -62,7 +62,7 @@
   "minimal": {
     "xml": [
       "<ubcpi>",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Sample Peer Rationale Reflection</display_name>",
         "<question>",
             "<text>This is the question text</text>",
         "</question>",
@@ -81,7 +81,7 @@
       "</ubcpi>"
     ],
     "expect": {
-      "display_name": "Sample Peer Instruction",
+      "display_name": "Sample Peer Rationale Reflection",
       "question_text": {
         "text": "This is the question text"
       },
@@ -108,7 +108,7 @@
   "unicode": {
     "xml": [
       "<ubcpi rationale_size_min=\"1\" rationale_size_max=\"32000\" algorithm=\"simple\" num_responses=\"#\">",
-      "<display_name>样品 Peer Instruction</display_name>",
+      "<display_name>样品 Peer Rationale Reflection</display_name>",
       "<question>",
       "<text>这是一个问题</text>",
       "<image position=\"below\" alt=\"图像\" show_fields=\"0\">/static/test.jpg</image>",
@@ -130,7 +130,7 @@
       "</ubcpi>"
     ],
     "expect": {
-      "display_name": "样品 Peer Instruction",
+      "display_name": "样品 Peer Rationale Reflection",
       "question_text": {
         "image_url": "/static/test.jpg",
         "image_position": "below",

--- a/ubcpi/test/data/parse_from_xml_errors.json
+++ b/ubcpi/test/data/parse_from_xml_errors.json
@@ -2,7 +2,7 @@
   "invalid_ubcpi_element": {
     "xml": [
       "<ubcpi_invalid>",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Sample Peer Rationale Reflection</display_name>",
         "<question>",
             "<text>This is the question text</text>",
         "</question>",
@@ -45,7 +45,7 @@
   "missing_question_element": {
     "xml": [
       "<ubcpi>",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Sample Peer Rationale Reflection</display_name>",
         "<options>",
             "<option correct=\"True\">",
                 "<text>Option1</text>",
@@ -64,7 +64,7 @@
   "missing_options_element": {
     "xml": [
       "<ubcpi>",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Peer Rationale Reflection</display_name>",
         "<question>",
             "<text>This is the question text</text>",
         "</question>",
@@ -77,7 +77,7 @@
   "missing_seeds_element": {
     "xml": [
       "<ubcpi>",
-        "<display_name>Sample Peer Instruction</display_name>",
+        "<display_name>Peer Rationale Reflection</display_name>",
         "<question>",
             "<text>This is the question text</text>",
         "</question>",

--- a/ubcpi/test/data/update_xblock.json
+++ b/ubcpi/test/data/update_xblock.json
@@ -1,6 +1,6 @@
 {
   "basic": {
-    "display_name": "Peer Instruction",
+    "display_name": "Peer Rationale Reflection",
     "question_text": {
       "text": "What is the answer to life, the universe and everything?",
       "image_alt": "",

--- a/ubcpi/test/data/validate_form.json
+++ b/ubcpi/test/data/validate_form.json
@@ -1,6 +1,6 @@
 {
   "valid": {
-    "display_name": "Peer Instruction1",
+    "display_name": "Peer Rationale Reflection1",
     "question_text": {
       "text": "What is the answer to life, the universe and everything?",
       "image_show_fields": 0,

--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -177,7 +177,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
     event_namespace = 'ubc.peer_instruction'
 
     # the display name that used on the interface
-    display_name = String(default=_("Peer Instruction Question"))
+    display_name = String(default=_("Peer Rationale Reflection Question"))
 
     question_text = Dict(
         default={'text': _('<p>Where does most of the mass in a fully grown tree originate?</p>'),
@@ -650,7 +650,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
         """A canned scenario for display in the workbench."""
         return [
             (
-                "UBC Peer Instruction: Basic",
+                "UBC Peer Rationale Reflection: Basic",
                 cls.resource_string('static/xml/basic_scenario.xml')
             ),
         ]


### PR DESCRIPTION
Change both initial and final answers to have the same colouring for
final results. Remove graph headings at the bottom of graphs. Remove
"correct answer" text below rationale area when no correct answer is
defined.

Change introductory text in studio view to include scenario
with no correct answer. Change "rationale" to "explanation" in studio
view. Also add text about selecting "n/a".

Put progress bar back in for studio view.