### PR TITLE
Convert all course_ids to strings before sending to submissions API.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def readme():
 
 setup(
     name='ubcpi-xblock',
-    version='0.6.2',
+    version='0.6.3',
     description='UBC Peer Instruction XBlock',
     long_description=readme(),
     license='Affero GNU General Public License v3 (GPLv3)',

--- a/ubcpi/test/test_lms.py
+++ b/ubcpi/test/test_lms.py
@@ -123,21 +123,21 @@ class LmsTest(XBlockHandlerTestCaseMixin, TestCase):
         xblock.scope_ids.user_id = None
         student_item = xblock.get_student_item_dict()
         self.assertEqual(student_item, {
-            'student_id': None,
+            'student_id': '',
             'item_id': 'usage_id',
             'course_id': 'edX/Enchantment_101/April_1',
             'item_type': 'ubcpi'
         })
 
         # mock the LMS environment
-        xblock.course_id = 'course 101'
         xblock.xmodule_runtime = Mock()
+        xblock.xmodule_runtime.course_id.to_deprecated_string = Mock(return_value='course 101')
         xblock.xmodule_runtime.anonymous_student_id = 'anonymous'
 
         student_item = xblock.get_student_item_dict()
         self.assertEqual(student_item, {
             'student_id': 'anonymous',
-            'item_id': 'usage_id',
+            'item_id': u'usage_id',
             'course_id': 'course 101',
             'item_type': 'ubcpi'
         })

--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -82,6 +82,8 @@ class MissingDataFetcherMixin:
 
     Copied from https://github.com/edx/edx-ora2/blob/master/openassessment/xblock/openassessmentblock.py
     """
+    def get_course_id(self):
+        return self._serialize_opaque_key(self.xmodule_runtime.course_id)
 
     def get_student_item_dict(self, anonymous_user_id=None):
         """Create a student_item_dict from our surrounding context.
@@ -100,7 +102,7 @@ class MissingDataFetcherMixin:
         # This is not the real way course_ids should work, but this is a
         # temporary expediency for LMS integration
         if hasattr(self, "xmodule_runtime"):
-            course_id = self.course_id  # pylint:disable=E1101
+            course_id = self.get_course_id()  # pylint:disable=E1101
 
             if anonymous_user_id:
                 student_id = anonymous_user_id
@@ -109,7 +111,7 @@ class MissingDataFetcherMixin:
         else:
             course_id = "edX/Enchantment_101/April_1"
             if self.scope_ids.user_id is None:
-                student_id = None
+                student_id = ''
             else:
                 student_id = unicode(self.scope_ids.user_id)
 


### PR DESCRIPTION
We've recently upgraded the version of Django Rest Framework used by edx-platform to v3.6.3 from v3.2.3. This upgrade made the ubcpi XBlock to no longer function properly in some (or all) circumstances, due to the new strictness of DRF - it only wants strings for CharField fields in Django models. This XBlock is passing the course_id object instead of the string representation.

This change should fix the problem.
