### PR TITLE
Add mobile support

### DIFF
--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -430,6 +430,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
         else:
             return static_url
 
+    @XBlock.supports('multi_device') # Mark as mobile-friendly
     def student_view(self, context=None):
         """
         The primary view of the PeerInstructionXBlock, shown to students when viewing courses.


### PR DESCRIPTION
## Description 
This change allows to use the xblock on edx mobiles apps, adding the "multi_device" decorator
![screenshot_1537898177](https://user-images.githubusercontent.com/36200299/46032918-7c83c900-c0c2-11e8-96c8-244255438bc1.png)
## Suggested reviewers
@xcompass 
@lenglund 

