### PR TITLE
Fix issues with multiple ubcpi xblocks in same unit

### DIFF
--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -74,7 +74,7 @@
 
                     <div class="ubcpi-possible-options">
                         <p class="ubcpi-option" data-ng-repeat="option in options track by $index">
-                            <label class="ubcpi-label ubcpi-answer" for="original-option-input-{{ $index }}">
+                            <label class="ubcpi-label ubcpi-answer">
                                 <input class="ubcpi-field" type="radio" id="original-option-input-{{ $index }}" name="q" data-ng-model="rc.answer" value="{{$index}}" required integer>
 
                                 <img ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" ng-if="option.image_position == 'above' && option.image_url" />
@@ -130,7 +130,7 @@
                         </div>
                 </div>
 
-                <input data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }} &rarr;" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints" onclick=""/>
+                <input data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }} &rarr;" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints" scroll-to-top-of-block='click' onclick=""/>
 
             </form>
 

--- a/ubcpi/static/js/src/ubcpi.js
+++ b/ubcpi/static/js/src/ubcpi.js
@@ -53,6 +53,28 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
         };
     }])
 
+    /**
+     * Scroll to top of the xblock on given event
+     */
+    .directive('scrollToTopOfBlock', function() {
+        return {
+            restrict: 'A',
+            scope: {
+                scrollToTopOfBlock: '@'
+            },
+            link: function(scope, ele, attr, ctrl) {
+                ele.on(scope.scrollToTopOfBlock? scope.scrollToTopOfBlock : 'click', function() {
+                    var target;
+                    target = ele.parents('.ubcpi_block');
+                    if (!target) {
+                        target = ele;
+                    }
+                    $('html,body').animate({scrollTop: target.offset().top}, "slow");
+                });
+            }
+        };
+    })
+
     .factory('backendService', ['$http', '$q', '$rootScope', function ($http, $q, $rootScope) {
         return {
             getStats: getStats,
@@ -101,8 +123,8 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
         }
     }])
 
-    .controller('ReviseController', ['$scope', 'notify', 'backendService', '$q', 'gettext', '$location', '$anchorScroll', '$timeout',
-        function ($scope, notify, backendService, $q, gettext, $location, $anchorScroll, $timeout) {
+    .controller('ReviseController', ['$scope', 'notify', 'backendService', '$q', 'gettext', '$location',
+        function ($scope, notify, backendService, $q, gettext, $location) {
             var self = this;
             var data = $scope.config.data;
 
@@ -121,7 +143,7 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
             var persistedDataObject = get_data().then( function(persistedData) {
 
                 if ( persistedData.answer_original !== null ) {
-                    assignData(self, data);
+                    assignData(self, persistedData);
                 }
             });
 
@@ -154,10 +176,6 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                 self.submitting = true;
                 return backendService.submit(self.answer, self.rationale, self.status()).then(function(data) {
                     assignData(self, data);
-                    $timeout(function() {
-                        $location.hash('others-responses');
-                        $anchorScroll();
-                    });
                 }, function(error) {
                     notify('error', {
                         'title': gettext('Error submitting answer!'),
@@ -185,7 +203,7 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
             self.calc = function(s) {
                 var originalPercentage = gettext(" Initial Answer Selection: ");
                 var revisedPercentage = gettext(" Final Answer Selection: ");
-                if (typeof self.stats.original[s] !== 'undefined') {
+                if (typeof self.stats !== 'undefined' && typeof s !== 'undefined' && typeof self.stats.original[s] !== 'undefined') {
                     var totalCounts = 0;
                     for (var i = 0; i < data.options.length; i++) {
                         if (typeof self.stats.original[i] !== 'undefined')
@@ -196,7 +214,7 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                 else
                     originalPercentage += "0%";
 
-                if (typeof self.stats.revised[s] !== 'undefined') {
+                if (typeof self.stats !== 'undefined' && typeof s !== 'undefined' && typeof self.stats.revised[s] !== 'undefined') {
                     var totalCounts = 0;
                     for (var i = 0; i < data.options.length; i++) {
                         if (typeof self.stats.revised[i] !== 'undefined')


### PR DESCRIPTION
- fix the issue that if there are multiple ubcpi in the same unit,
clicking on an answer text will jump to the top of the page and the
answer is not selected

- fix the issue that when the subsection has multiple units with ubcpi,
clicking on submit button will jump to the top of the page

- fix the issue that when the student finished Step 1 and switch to
another unit and back, persisted data is not displayed and Step 1 is
displayed again

Closes #152
Closes #33