### PR TITLE
  Fix no correct answer validation error

### DIFF
--- a/ubcpi/serialize.py
+++ b/ubcpi/serialize.py
@@ -123,8 +123,12 @@ def parse_options_xml(root):
     options = []
     correct_option = None
     rationale = None
+    options_list = root.findall('option')
 
-    for option_el in root.findall('option'):
+    if len(options_list) == 0:
+        raise ValidationError(_('Missing options elements in XML definition'))
+
+    for option_el in options_list:
         option_dict = dict()
         option_prompt_el = option_el.find('text')
         if option_prompt_el is not None:
@@ -149,7 +153,7 @@ def parse_options_xml(root):
         options.append(option_dict)
 
     if correct_option is None or rationale is None:
-        raise ValidationError(_('Correct answer and rationale are required and have to be defined in one of the option.'))
+        correct_option = len(options)
 
     return options, correct_option, rationale
 

--- a/ubcpi/test/data/parse_options_xml.json
+++ b/ubcpi/test/data/parse_options_xml.json
@@ -83,5 +83,29 @@
       "correct_answer": 0,
       "correct_rationale": {"text": "This is correct."}
     }
+  },
+  "missing_correct_answer": {
+    "xml": [
+      "<options>",
+        "<option>",
+          "<text>Option1</text>",
+        "</option>",
+        "<option>",
+          "<text>Option2</text>",
+        "</option>",
+      "</options>"
+    ],
+    "expect": {
+      "options": [
+        {
+          "text": "Option1"
+        },
+        {
+          "text": "Option2"
+        }
+      ],
+      "correct_answer": 2,
+      "correct_rationale": null
+    }
   }
 }

--- a/ubcpi/test/data/parse_options_xml_errors.json
+++ b/ubcpi/test/data/parse_options_xml_errors.json
@@ -1,17 +1,4 @@
 {
-  "missing_correct_answer": {
-    "xml": [
-      "<options>",
-        "<option>",
-            "<image position=\"below\" alt=\"This is a image\">/static/test1.jpg</image>",
-            "<text>Option1</text>",
-        "</option>",
-        "<option>",
-            "<text>Option2</text>",
-        "</option>",
-      "</options>"
-    ]
-  },
   "missing_correct_rationale": {
     "xml": [
       "<options>",


### PR DESCRIPTION
This PR fixes the validation error when no correct answer is provided. This was a missing case from the PR  https://github.com/ubc/ubcpi/pull/98/files when there is no correct answer provided it raised Validation error. In result of validation error import of ubcpi xblock was failed.