### PR TITLE
Use locale name instead of language name

### DIFF
--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -6,7 +6,6 @@ import uuid
 
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
-from django.utils import translation
 import pkg_resources
 from webob import Response
 from xblock.core import XBlock
@@ -14,7 +13,7 @@ from xblock.exceptions import JsonHandlerError
 from xblock.fields import Scope, String, List, Dict, Integer, DateTime, Float
 from xblock.fragment import Fragment
 from xblockutils.publish_event import PublishEventMixin
-from .utils import _  # pylint: disable=unused-import
+from .utils import _, get_language # pylint: disable=unused-import
 
 from answer_pool import offer_answer, validate_seeded_answers, get_other_answers
 import persistence as sas_api
@@ -319,7 +318,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
                 'below': self.ugettext('Appears below')
             },
             'seeds': self.seeds,
-            'lang': translation.get_language(),
+            'lang': get_language(),
         })
 
         return frag
@@ -481,7 +480,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
             'rationale_size': self.rationale_size,
             'user_role': self.get_user_role(),
             'all_status': {'NEW': STATUS_NEW, 'ANSWERED': STATUS_ANSWERED, 'REVISED': STATUS_REVISED},
-            'lang': translation.get_language(),
+            'lang': get_language(),
         }
         if answers.has_revision(0) and not answers.has_revision(1):
             js_vals['other_answers'] = self.other_answers_shown

--- a/ubcpi/utils.py
+++ b/ubcpi/utils.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 
+from django.utils import translation
 
 # Make '_' a no-op so we can scrape strings
 def _(text):
     return text
+
+def get_language():
+    """
+    Return the locale name of the user language.
+    """
+    return translation.to_locale(translation.get_language())


### PR DESCRIPTION
There is a problem with the translations (see https://github.com/ubc/ubcpi/pull/159)

The translations catalog(ubcpi/static/js/src/translations.js) is generated using locale names and translations from transifex. 

The django.utils.translation.get_language() function returns the language code (i.e. es-419), but since in the catalog we are using locale names(i.e. es_419), the strings are not being translated as expected.

With this change, now we are using the locale names and it works fine. I tested this with spanish

