### PR TITLE
New UI for ubcpi

### DIFF
--- a/ubcpi/answer_pool.py
+++ b/ubcpi/answer_pool.py
@@ -1,4 +1,5 @@
 import random
+import copy
 import persistence as sas_api
 from utils import _  # pylint: disable=unused-import
 
@@ -172,6 +173,52 @@ def validate_seeded_answers(answers, options, algo):
     else:
         raise UnknownChooseAnswerAlgorithm()
 
+def get_other_answers_count(pool, seeded_answers, get_student_item_dict):
+    """
+    Count of available answers and seeds in the pool for each option
+
+    Args:
+        pool (dict): answer pool, format:
+            {
+                option1_index: {
+                    student_id: { can store algorithm specific info here }
+                },
+                option2_index: {
+                    student_id: { ... }
+                }
+            }
+        seeded_answers (list): seeded answers from instructor
+            [
+                {'answer': 0, 'rationale': 'rationale A'},
+                {'answer': 1, 'rationale': 'rationale B'},
+            ]
+        get_student_item_dict (callable): get student item dict function to return student item dict
+
+    Returns:
+        dict: count for each option
+        {
+            0: 4,
+            1: 2,
+            3: 1,
+            ...
+        }
+
+    """
+    ret = {}
+
+    # clean up answers so that all keys are int
+    pool = {int(k): v for k, v in pool.items()}
+    merged_pool = convert_seeded_answers(seeded_answers)
+    student_id = get_student_item_dict()['student_id']
+    for key in pool:
+        merged_pool.setdefault(key, {})
+        merged_pool[key].update(pool[key])
+        # Pop student's own answer, if exists
+        merged_pool[key].pop(student_id, None)
+
+    for key in merged_pool:
+        ret[key] = len(merged_pool.get(key, {}))
+    return ret
 
 def get_other_answers(pool, seeded_answers, get_student_item_dict, algo, options):
     """
@@ -321,6 +368,96 @@ def get_other_answers_random(pool, seeded_answers, get_student_item_dict, num_re
         ret.append({'option': option, 'rationale': rationale})
 
     return {"answers": ret}
+
+
+def refresh_answers(answers_shown, option, pool, seeded_answers, get_student_item_dict, seeded_first=False):
+    """
+    Refresh the answers shown for given option
+
+    Args:
+        answers_shown (dict): answers being shown that need to be refreshed. Format:
+            {'answers': [
+                {'option': 0, 'rationale': 'rationale A'},
+                {'option': 1, 'rationale': 'rationale B'},
+            ]}
+        option (int): the option to refresh
+        pool (dict): answer pool, format:
+            {
+                option1_index: {
+                    student_id: { can store algorithm specific info here }
+                },
+                option2_index: {
+                    student_id: { ... }
+                }
+            }
+        seeded_answers (list): seeded answers from instructor
+            [
+                {'answer': 0, 'rationale': 'rationale A'},
+                {'answer': 1, 'rationale': 'rationale B'},
+            ]
+        get_student_item_dict (callable): get student item dict function to return student item dict
+        seeded_first (boolean): refresh with answers from seeded_answers first, when exhausted, pick from pool
+
+    Returns:
+        dict: refreshed answers lists
+        {
+            'answers':
+                [
+                    {'option': 0, 'rationale': 'rationale A'},
+                    {'option': 1, 'rationale': 'rationale B'},
+                ]
+        }
+    """
+    ret = copy.deepcopy(answers_shown)
+    # clean up answers so that all keys are int
+    pool = {int(k): v for k, v in pool.items()}
+    seeded_pool = convert_seeded_answers(seeded_answers)
+    student_id = get_student_item_dict()['student_id']
+
+    available_students = copy.deepcopy(pool.get(option, {}))
+    available_students.pop(student_id, None)
+    # if seed answers have higher priority, fill the available seeds.
+    # otherwise merge them into available students
+    available_seeds = {}
+    if seeded_first and seeded_pool.get(option, {}):
+        available_seeds = copy.deepcopy(seeded_pool.get(option, {}))
+    else:
+        for key in seeded_pool.get(option, {}):
+            available_students[key] = seeded_pool.get(option, {}).get(key, None)
+
+    for answer in ret.get('answers', []):
+        if answer.get('option', None) == option:
+            rationale = None
+
+            while available_seeds:
+                key = random.choice(available_seeds.keys())
+                rationale = available_seeds.pop(key, None)
+                if rationale is not None:
+                    answer['rationale'] = rationale
+                    break;
+
+            while available_students and rationale is None:
+                key = random.choice(available_students.keys())
+                # remove the chosen answer from pool
+                content = available_students.pop(key, None)
+
+                if key.startswith('seeded'):
+                    rationale = content
+                else:
+                    student_item = get_student_item_dict(key)
+                    submission = sas_api.get_answers_for_student(student_item)
+                    # Make sure the answer is still the one we want.
+                    # It may have changed (e.g. instructor deleted the student state
+                    # and the student re-submitted a diff answer)
+                    if submission.has_revision(0) and submission.get_vote(0) == option:
+                        rationale = submission.get_rationale(0)
+
+                if rationale:
+                    answer['rationale'] = rationale
+                    break
+
+    # random.shuffle(ret['answers'])
+    return ret
 
 
 def convert_seeded_answers(answers):

--- a/ubcpi/persistence.py
+++ b/ubcpi/persistence.py
@@ -17,6 +17,8 @@ answer_item has to be in the format:
 """
 
 ANSWER_LIST_KEY = 'answers'
+DELETE_INDICATOR = 'deleted'
+REQUEST_USER_ID_KEY = 'requesting_user_id'
 
 VOTE_KEY = 'vote'
 RATIONALE_KEY = 'rationale'
@@ -39,6 +41,8 @@ def get_answers_for_student(student_item):
 
     latest_submission = submissions[0]
     latest_answer_item = latest_submission.get('answer', {})
+    if latest_answer_item.get(DELETE_INDICATOR, False):
+        return Answers()
     return Answers(latest_answer_item.get(ANSWER_LIST_KEY, []))
 
 
@@ -59,6 +63,19 @@ def add_answer_for_student(student_item, vote, rationale):
         ANSWER_LIST_KEY: answers.get_answers_as_list()
     })
 
+def delete_answer_for_student(student_item, requesting_user_id):
+    """
+    Create a new submission to indicate student's answer is deleted
+
+    Args:
+        student_item (dict): The location of the problem this submission is
+            associated with, as defined by a course, student, and item.
+        requesting_user_id: The user that is requesting to delete student answer
+    """
+    sub_api.create_submission(student_item, {
+        DELETE_INDICATOR: True,
+        REQUEST_USER_ID_KEY: requesting_user_id,
+    })
 
 class Answers:
     """

--- a/ubcpi/static/css/ubcpi.css
+++ b/ubcpi/static/css/ubcpi.css
@@ -52,6 +52,7 @@ fieldset .ubcpi-label {
     border-radius: 3px;
     padding: 10px;
     width: 100%;
+    background-color: #fbfbfb;
 }
 
 fieldset .ubcpi-label:hover {
@@ -189,10 +190,6 @@ div.course-wrapper section.course-content .vert-mod > div ul.ubcpi-other-answers
 div.course-wrapper section.course-content .vert-mod > div ul.ubcpi-other-answers li {
     margin: 0.75em;
     border-bottom: 1px solid #cfc6c6;
-}
-
-div.course-wrapper section.course-content .vert-mod .sample-answer-list > :not(:first-child) {
-    border-top: 1px solid #cfc6c6;
 }
 
 div.course-wrapper section.course-content .vert-mod .sample-answer {
@@ -625,10 +622,28 @@ text.ubcpibar.label {
     border: 2px solid #e5e5e5;
     border-radius: 3px;
     padding: 10px;
+    background-color: #fbfbfb;
 }
 
 .ubcpi-breakdown-answer-options .ubcpi-option .ubcpi-breakdown-answer-text {
     display: block;
+}
+
+.ubcpi-refresh-section {
+    margin: 1em;
+    border-top: 1px solid #cfc6c6;
+    color: #0075b4;
+}
+
+.ubcpi-refresh-option-button * {
+    font-size: 0.9em;
+    transition: none;
+    cursor: pointer;
+}
+
+.ubcpi-refresh-option-button-disabled {
+    pointer-events: none;
+    color: #888;
 }
 
 #pi-form .list-input.settings-list .setting-label {

--- a/ubcpi/static/css/ubcpi.css
+++ b/ubcpi/static/css/ubcpi.css
@@ -25,11 +25,6 @@ h2.question-text {
     padding: 0;
 }
 
-.choicegroup fieldset .ubcpi-possible-options {
-    padding-left: 20px;
-    border-left: 2px solid #e5e5e5;
-}
-
 div.course-wrapper section.course-content fieldset .ubcpi-option {
     margin: 0;
 }
@@ -77,6 +72,20 @@ fieldset .ubcpi-option:last-of-type .ubcpi-label {
     float: none;
 }
 
+.ubcpi-no-pointer {
+    cursor: default;
+}
+
+.ubcpi-answer img {
+    display: block;
+}
+
+.ubcpi-label.ubcpi-explain-label {
+    border: none;
+    margin-bottom: 0;
+    padding: 0px;
+}
+
 .results-container .ubcpi-label {
     margin-bottom: 15px;
 }
@@ -116,7 +125,8 @@ textarea.ubcpi-field {
     -webkit-font-smoothing: antialiased;
 }
 
-.choicegroup .ubcpi_submit {
+.choicegroup .ubcpi_submit,
+.others-responses .ubcpi_submit {
     padding: 10px 40px;
     border: 1px solid #2b8dbb;
     color: #fff;
@@ -140,7 +150,10 @@ textarea.ubcpi-field {
 
 .ubcpi_block .choicegroup .ubcpi_submit:hover,
 .ubcpi_block .choicegroup .ubcpi_submit:active,
-.ubcpi_block .choicegroup .ubcpi_submit:focus {
+.ubcpi_block .choicegroup .ubcpi_submit:focus,
+.others-responses .ubcpi_submit:hover,
+.others-responses .ubcpi_submit:active,
+.others-responses .ubcpi_submit:focus {
     border-color: #00a7f6;
     box-shadow: none;
     background: #00a7f6 none;
@@ -178,8 +191,30 @@ div.course-wrapper section.course-content .vert-mod > div ul.ubcpi-other-answers
     border-bottom: 1px solid #cfc6c6;
 }
 
-div.course-wrapper section.course-content .vert-mod > div ul.ubcpi-other-answers li:last-of-type {
-    border-bottom: none;
+div.course-wrapper section.course-content .vert-mod .sample-answer-list > :not(:first-child) {
+    border-top: 1px solid #cfc6c6;
+}
+
+div.course-wrapper section.course-content .vert-mod .sample-answer {
+    margin: 1em;
+    display: block;
+}
+
+div.course-wrapper section.course-content .vert-mod .no-sample-answer {
+    font-style: italic;
+    margin: 1em;
+    display: block;
+}
+
+div.course-wrapper section.course-content .vert-mod .sample-answer .other-rationale {
+    line-height: 140%;
+    padding-left: 1em;
+}
+
+div.course-wrapper section.course-content .vert-mod .own-answer {
+    padding-top: 15px;
+    margin: 1em;
+    font-weight: bold;
 }
 
 .ubcpi-other-answers,
@@ -198,8 +233,15 @@ div.course-wrapper section.course-content .vert-mod > div ul.ubcpi-other-answers
 }
 
 .ubcpi-other-answers h4,
-.ubcpi-solution-your-initial-answer,
+.ubcpi-solution-your-initial-answer {
+    font-weight: 900;
+}
+
 .ubcpi-solution-your-final-answer {
+    border-top: 1px solid #ddd;
+    margin-top: 10px;
+    padding-top: 5px;
+    font-size: 0.85em;
     font-weight: 900;
 }
 
@@ -385,7 +427,6 @@ textarea.pi-options {
     position: relative;
     margin: 20px 0;
     border: 1px solid #d7dbdf;
-    border-left: 10px solid #b9c1c8;
     box-shadow: inset 0 1px 2px 1px rgba(2, 2, 3, 0.1);
     padding: 20px;
     background: #fdfdfd;
@@ -499,8 +540,26 @@ label.ubcpi-label {
     fill: #50c67b;
 }
 
-.ubcpibar:hover {
-    opacity: 1.0;
+.ubcpibar.original {
+    opacity: 0.4;
+}
+
+text.ubcpibar {
+    font-size: 12px;
+    font-weight: 600;
+    fill: #000000;
+}
+
+text.ubcpibar.correct-answer {
+    font-size: 12px;
+    font-weight: 600;
+    fill: #000000;
+}
+
+text.ubcpibar.label {
+    font-size: 12px;
+    font-weight: 600;
+    fill: #000000;
 }
 
 .ubcpi-correct-answer-option {
@@ -509,6 +568,11 @@ label.ubcpi-label {
 }
 
 .ubcpi-show-correct {
+    font-size: 0.85em;
+}
+
+.ubcpi-correct-answer-highlight {
+    font-weight: bold;
     color: #50c67b;
 }
 
@@ -525,11 +589,13 @@ label.ubcpi-label {
 .ubcpi-correct-answer-rationale {
     display: block;
     margin-bottom: 20px;
+    font-size: 0.85em;
 }
 
 .ubcpi-solution-rationales {
     padding-left: 10px;
     word-break: break-all;
+    font-weight: normal;
 }
 
 .other-rationale {
@@ -628,6 +694,12 @@ div.course-wrapper section.course-content .warning-notice p {
 
 .possible-option {
     font-style: italic;
+}
+
+#decision-prompt {
+    font-weight: normal;
+    font-size: 120%;
+    padding-right: 4.8em;
 }
 
 .response-text {
@@ -780,4 +852,6 @@ pi-barchart > svg {
     text-transform: capitalize;
 }
 
-
+#not-enough-data {
+    font-size: 0.85em;
+}

--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -20,7 +20,7 @@
 
             <a id="reflecting" name="reflecting"></a>
 
-            <div role="group" aria-label="Progress Indicator">
+            <div class="ubcpi_progress_bar" role="group" aria-label="Progress Indicator">
                 <span id="answer" data-ng-if="rc.status() == rc.ALL_STATUS.NEW">
                     <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
                         <li style="display:inline-block;width:30%;text-align:center;font-weight:bold;color:#111111;padding-top:.3em"><span class="fa fa-arrow-circle-down" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, In Progress</span></li>
@@ -47,13 +47,13 @@
                     <legend>
                         <span data-ng-if="rc.status() == rc.ALL_STATUS.NEW" style="color:#414141" translate>Step 1) Give Initial Answer <span class="inline-hint">You can change this answer later, if you change your mind.</span></span>
                         <span data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED" style="color:#414141" translate>Step 2) Read Other Student Answers
-                            <p class="ubcpi-other-answers-instructions" translate>These are samples of other student answers for this question. Read them and then compare with your answer below.</p>
+                            <p class="ubcpi-other-answers-instructions" translate>These are randomly chosen samples of other student answers for this question. Read them and compare with your answer below. Then you may revise your answer, if you wish.</p>
                         </span>
                     </legend>
 
                     <div id="hiding-options-div" class="ubcpi-possible-options">
                         <div class="ubcpi-option" data-ng-repeat="(optionKey, option) in options track by $index">
-                            <label class="ubcpi-label ubcpi-answer" data-ng-class="{'ubcpi-no-pointer': rc.status() == rc.ALL_STATUS.ANSWERED && !rc.revising}" for="original-option-input-{{ $index }}">
+                            <label class="ubcpi-label ubcpi-answer" data-ng-class="{'ubcpi-no-pointer': rc.status() == rc.ALL_STATUS.ANSWERED && !rc.revising}">
                                 <input class="ubcpi-field" type="radio" id="original-option-input-{{ $index }}" data-ng-if="rc.status() == rc.ALL_STATUS.NEW || rc.revising" name="q" data-ng-model="rc.answer" value="{{optionKey}}" required integer>
 
                                 <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'above' && option.image_url" />
@@ -68,6 +68,9 @@
                                             <span class="sr" translate>Student Rationale</span><i aria-hidden="true" class="icon fa fa-user fa-lg"></i>
                                             <span class="other-rationale">"{{otherAnswer.rationale}}"</span>
                                         </div>
+                                    </div>
+                                    <div class="ubcpi-refresh-section" data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED && !rc.revising">
+                                        <span class="ubcpi-refresh-option-button" data-ng-class="{'ubcpi-refresh-option-button-disabled': rc.alt_answers_available && !rc.alt_answers_available[optionKey]}" ubcpi-refresh-rationale ubcpi-option="{{optionKey}}" ubcpi-refresh-model="rc.other_answers.answers" translate></span>
                                     </div>
                                 </div>
                                 <div class="no-sample-answer" ng-if="rc.status() == rc.ALL_STATUS.ANSWERED && !rc.hasSampleExplanationForOption(optionKey)">
@@ -98,7 +101,7 @@
                                     </p>
 
                                     <div style="text-align: right;" data-ng-if="!rc.revising">
-                                        <input id="submit-button" onclick="this.blur();" style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints"/>
+                                        <input id="submit-button" onclick="this.blur();" style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints" scroll-to-progress-bar='click'/>
                                     </div>
 
                                 </div>
@@ -110,9 +113,10 @@
                                         </div>
                                         <div style="text-align: right;">
                                             <p id="decision-prompt" style="text-align: right;" data-ng-if="!rc.revising" translate>What would you like to do?</p>
+                                            <input id="dummy-button" style="margin-right: 5px; display: inline-block; display:none;" type='button' class='ubcpi_submit' name='ubcpi_dummy' />
                                             <input id="update-button" style="margin-right: 5px; display: inline-block;" type='button' class='ubcpi_submit' data-ng-if="!rc.revising" value="{{ 'Revise Answer' | translate }}" name='ubcpi_update_step' data-ng-click="rc.revising=true;"/>
-                                            <input id="cancel-button" style="margin-right: 5px; display: inline-block;" type='button' class='ubcpi_submit' data-ng-if="rc.revising" value="{{ 'Cancel' | translate }}" name='ubcpi_update_step' data-ng-click="rc.answer=rc.answer_original; rc.rationale=rc.rationale_original; rc.revising=false;"/>
-                                            <input id="submit-button" style="display: inline-block;" onclick="this.blur(); " style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Submit Answer' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints"/>
+                                            <input id="cancel-button" style="margin-right: 5px; display: inline-block;" type='button' class='ubcpi_submit' data-ng-if="rc.revising" value="{{ 'Cancel' | translate }}" name='ubcpi_update_step_cancel' data-ng-click="rc.answer=rc.answer_original; rc.rationale=rc.rationale_original; rc.revising=false;"/>
+                                            <input id="submit-button" style="display: inline-block;" onclick="this.blur(); " style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Submit Answer' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints" scroll-to-progress-bar='click' onclick=""/>
                                         </div>
                                     </div>
                                 </div>
@@ -167,7 +171,7 @@
             <img data-ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" data-ng-if="question_text.image_position == 'below' && question_text.image_url" />
             </div>
 
-            <div id="finalReflecting" role="group" aria-label="Progress Indicator">
+            <div class="ubcpi_progress_bar" id="finalReflecting" role="group" aria-label="Progress Indicator">
                 <span id="test" data-ng-if="rc.status() == rc.ALL_STATUS.REVISED">
                     <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
                         <li style="display:inline-block;width:30%;text-align:center;color:#414141;padding-top:.3em"><span class="fa fa-check-circle" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, Completed</span></li>

--- a/ubcpi/static/html/ubcpi.html
+++ b/ubcpi/static/html/ubcpi.html
@@ -5,59 +5,36 @@
         <div class="question-other-explain" data-ng-if="rc.status() == rc.ALL_STATUS.NEW || rc.status() == rc.ALL_STATUS.ANSWERED">
 
             <h3 id="pi-question-h" class="question-text" style="display:inline;">{{display_name}}</h3>
-            <div class="question-weight" ng-if="weight < 1"></div>
-            <div class="question-weight" ng-if="weight == 1" translate>&nbsp;({{weight}} point possible)</div>
-            <div class="question-weight" ng-if="weight > 1" translate>&nbsp;({{weight}} points possible)</div>
+            <div class="question-weight" data-ng-if="weight < 1"></div>
+            <div class="question-weight" data-ng-if="weight == 1" translate>({{weight}} point possible)</div>
+            <div class="question-weight" data-ng-if="weight > 1" translate>({{weight}} points possible)</div>
 
             <div style="padding: .5em; margin-bottom: 0px; margin-top: 10px; background: #ddd;"><h4 id="pi-question-h2" class="question-text" style="margin-bottom:0;color:#414141" translate>Question</h4></div>
             <div style="margin: 0 0 1.5em 0; padding: 1em; background: #f8f8f8;">
-            <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'above' && question_text.image_url" />
+            <img data-ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" data-ng-if="question_text.image_position == 'above' && question_text.image_url" />
 
-            <span aria-labelledby="pi-question-h" id="question-text" ng-bind-html="question_text.text" ng-if="question_text.text"></span>
+            <span aria-labelledby="pi-question-h" id="question-text" data-ng-bind-html="question_text.text" data-ng-if="question_text.text"></span>
 
-            <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'below' && question_text.image_url" />
+            <img data-ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" data-ng-if="question_text.image_position == 'below' && question_text.image_url" />
             </div>
 
-            <a name="reflecting"></a>
-            <div role="group" aria-label="Progress Indicator">
-                <span id="reflect" ng-if="rc.status() == rc.ALL_STATUS.ANSWERED">
-                    <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
-                        <li style="display:inline-block;width:30%;text-align:center;color:#414141;padding-top:.3em"><span class="fa fa-check-circle" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, Completed</span></li>
-                            <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
-                        <li style="display:inline-block;width:30%;text-align:center;font-weight:bold;color:#111111;padding-top:.3em;"><span class="fa fa-arrow-circle-down" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Reflection</span><span class="sr" translate>, In Progress</span></li>
-                            <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
-                        <li style="display:inline-block;width:30%;text-align:center;color:#414141"><span class="fa fa-circle-o" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Results</span><span class="sr" translate>, Upcoming</span></li>
-                    </ol>
-                </span>
-            </div>
-
-            <div class="others-responses" id="others-responses" data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED" tabindex="-1" role="region" aria-labelledby="ubcpi-other-answers-heading">
-
-                <span id="ubcpi-other-answers-heading" style="color:#414141" translate>Step 2) Read Other Students Answers</span>
-                <p class="ubcpi-other-answers-instructions" translate>These are samples of other student answers for this question. Read them and then compare with your answer below.</p>
-
-                <ul class="ubcpi-other-answers">
-                    <li data-ng-repeat="answer in rc.other_answers.answers">
-                        <img ng-src="{{options[answer.option].image_url}}" alt="{{options[answer.option].image_alt}}" ng-if="options[answer.option].image_position == 'above' && options[answer.option].image_url" />
-
-                        <b><div class="other-answer" ng-if="options[answer.option].text" translate>Student Answer: {{options[answer.option].text}}</div></b>
-
-                        <img ng-src="{{options[answer.option].image_url}}" alt="{{options[answer.option].image_alt}}" ng-if="options[answer.option].image_position == 'below' && options[answer.option].image_url" />
-                        <span class="sr" translate>Student Rationale</span><i aria-hidden="true" class="icon fa fa-user"></i>
-                        <span class="other-rationale">"{{answer.rationale}}"</span>
-
-                    </li>
-                </ul>
-
-            </div><!-- .others-responses -->
+            <a id="reflecting" name="reflecting"></a>
 
             <div role="group" aria-label="Progress Indicator">
-                <span id="answer" ng-if="rc.status() == rc.ALL_STATUS.NEW">
-
+                <span id="answer" data-ng-if="rc.status() == rc.ALL_STATUS.NEW">
                     <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
                         <li style="display:inline-block;width:30%;text-align:center;font-weight:bold;color:#111111;padding-top:.3em"><span class="fa fa-arrow-circle-down" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, In Progress</span></li>
                             <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
                         <li style="display:inline-block;width:30%;text-align:center;color:#414141;padding-top:.3em;"><span class="fa fa-circle-o" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Reflection</span><span class="sr" translate>, Upcoming</span></li>
+                            <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
+                        <li style="display:inline-block;width:30%;text-align:center;color:#414141"><span class="fa fa-circle-o" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Results</span><span class="sr" translate>, Upcoming</span></li>
+                    </ol>
+                </span>
+                <span id="reflect" data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED">
+                    <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
+                        <li style="display:inline-block;width:30%;text-align:center;color:#414141;padding-top:.3em"><span class="fa fa-check-circle" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, Completed</span></li>
+                            <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
+                        <li style="display:inline-block;width:30%;text-align:center;font-weight:bold;color:#111111;padding-top:.3em;"><span class="fa fa-arrow-circle-down" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Reflection</span><span class="sr" translate>, In Progress</span></li>
                             <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
                         <li style="display:inline-block;width:30%;text-align:center;color:#414141"><span class="fa fa-circle-o" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Results</span><span class="sr" translate>, Upcoming</span></li>
                     </ol>
@@ -68,69 +45,106 @@
                 <fieldset>
 
                     <legend>
-                        <span ng-if="rc.status() == rc.ALL_STATUS.NEW" style="color:#414141" translate>Step 1) Your Initial Answer <span class="inline-hint">You can change this answer later, if you change your mind.</span></span>
-                        <span ng-if="rc.status() == rc.ALL_STATUS.ANSWERED" style="color:#414141" translate>Step 3) Your Final Answer <span class="inline-hint">You now have the option to change your initial selection and explanation, if you wish.</span></span>
+                        <span data-ng-if="rc.status() == rc.ALL_STATUS.NEW" style="color:#414141" translate>Step 1) Give Initial Answer <span class="inline-hint">You can change this answer later, if you change your mind.</span></span>
+                        <span data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED" style="color:#414141" translate>Step 2) Read Other Student Answers
+                            <p class="ubcpi-other-answers-instructions" translate>These are samples of other student answers for this question. Read them and then compare with your answer below.</p>
+                        </span>
                     </legend>
 
-                    <div class="ubcpi-possible-options">
-                        <p class="ubcpi-option" data-ng-repeat="option in options track by $index">
-                            <label class="ubcpi-label ubcpi-answer">
-                                <input class="ubcpi-field" type="radio" id="original-option-input-{{ $index }}" name="q" data-ng-model="rc.answer" value="{{$index}}" required integer>
+                    <div id="hiding-options-div" class="ubcpi-possible-options">
+                        <div class="ubcpi-option" data-ng-repeat="(optionKey, option) in options track by $index">
+                            <label class="ubcpi-label ubcpi-answer" data-ng-class="{'ubcpi-no-pointer': rc.status() == rc.ALL_STATUS.ANSWERED && !rc.revising}" for="original-option-input-{{ $index }}">
+                                <input class="ubcpi-field" type="radio" id="original-option-input-{{ $index }}" data-ng-if="rc.status() == rc.ALL_STATUS.NEW || rc.revising" name="q" data-ng-model="rc.answer" value="{{optionKey}}" required integer>
 
-                                <img ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" ng-if="option.image_position == 'above' && option.image_url" />
+                                <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'above' && option.image_url" />
 
                                 {{option.text}}
 
-                                <img ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" ng-if="option.image_position == 'below' && option.image_url" />
+                                <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'below' && option.image_url" />
 
-                                <span class="chosen-option option-details-text" ng-if="rc.answer_original == $index && rc.status() == rc.ALL_STATUS.ANSWERED" translate>(You chose this option)</span>
+                                <div class="sample-answer-list" id="sample-answer-list-{{ $index }}">
+                                    <div data-ng-repeat="otherAnswer in rc.other_answers.answers" data-ng-if="rc.status() == rc.ALL_STATUS.ANSWERED && optionKey == otherAnswer.option">
+                                        <div class="sample-answer">
+                                            <span class="sr" translate>Student Rationale</span><i aria-hidden="true" class="icon fa fa-user fa-lg"></i>
+                                            <span class="other-rationale">"{{otherAnswer.rationale}}"</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="no-sample-answer" ng-if="rc.status() == rc.ALL_STATUS.ANSWERED && !rc.hasSampleExplanationForOption(optionKey)">
+                                    (no student explanations were randomly selected for this answer)
+                                </div>
+                                <div data-ng-if="rc.answer == $index && (rc.status() == rc.ALL_STATUS.NEW || rc.revising)">
+                                    <label class="ubcpi-label ubcpi-explain-label" for="rationale" translate>Explain to other students why you chose this answer (required):</label>
+                                    <textarea class="ubcpi-field ubcpi-rationale" id="rationale" name="rationale" data-ng-model="rc.rationale" required data-ng-minlength="{{rationale_size.min}}" data-ng-maxlength="{{rationale_size.max}}"></textarea>
+                                    <p class="ubcpi-rationale-warning" data-ng-if="((rationale_size.max - rc.rationale.length) <= (rationale_size.max/10)) && (rc.rationale.length <= rationale_size.max)" translate>You are approaching the limit of {{rationale_size.max}} characters for this answer. Characters left: {{rationale_size.max - rc.rationale.length}}</p>
+
+                                    <div id="hiding-rationale-div" data-ng-if="answerForm.rationale.$error.minlength || answerForm.rationale.$error.maxlength">
+                                        <div id="button-disabled-reason-label">
+                                            <div class="message has-warnings warning-notice option-details-text">
+                                                <p role="alert" class="warning" id="button-disabled-reason">
+                                                    <span class="sr" translate>Warning</span>
+                                                    <i aria-hidden="true" class="icon fa fa-warning"></i>&nbsp;<span translate>Note:</span>
+                                                    <span data-ng-if="answerForm.rationale.$error.minlength" translate>Your explanation must be at least {{rationale_size.min}} characters long. Please explain further.</span>
+                                                    <span data-ng-if="answerForm.rationale.$error.maxlength" translate>Your explanation must contain fewer than {{rationale_size.max}} characters. Please trim the text.</span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <p class="ubc-pi-next">
+                                        <div id="ubcpi-next-inline-hints">
+                                            <span class="inline-hint" data-ng-if="rc.status() == rc.ALL_STATUS.NEW"><span class="sr">Hint</span><i aria-hidden="true" class="icon fa fa-info-circle"></i> <span translate>In the next step, you will be shown a selection of other responses that may help you refine your answer.</span></span>
+                                        </div>
+                                    </p>
+
+                                    <div style="text-align: right;" data-ng-if="!rc.revising">
+                                        <input id="submit-button" onclick="this.blur();" style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints"/>
+                                    </div>
+
+                                </div>
+
+                                <div data-ng-if="rc.answer == $index && rc.status() == rc.ALL_STATUS.ANSWERED">
+                                    <div class="own-answer">
+                                        <div data-ng-if="!rc.revising">
+                                            <span translate>You:</span>&nbsp;<span class="other-rationale">"{{rc.rationale_original}}"</span>
+                                        </div>
+                                        <div style="text-align: right;">
+                                            <p id="decision-prompt" style="text-align: right;" data-ng-if="!rc.revising" translate>What would you like to do?</p>
+                                            <input id="update-button" style="margin-right: 5px; display: inline-block;" type='button' class='ubcpi_submit' data-ng-if="!rc.revising" value="{{ 'Revise Answer' | translate }}" name='ubcpi_update_step' data-ng-click="rc.revising=true;"/>
+                                            <input id="cancel-button" style="margin-right: 5px; display: inline-block;" type='button' class='ubcpi_submit' data-ng-if="rc.revising" value="{{ 'Cancel' | translate }}" name='ubcpi_update_step' data-ng-click="rc.answer=rc.answer_original; rc.rationale=rc.rationale_original; rc.revising=false;"/>
+                                            <input id="submit-button" style="display: inline-block;" onclick="this.blur(); " style="display: inline; margin-left: 5px;" data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Submit Answer' | translate }}" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints"/>
+                                        </div>
+                                    </div>
+                                </div>
                             </label>
-                        </p>
+                        </div>
                     </div>
 
                 </fieldset>
 
-                <label class="ubcpi-label" for="rationale" translate>Explain to other students why you chose this answer (Required):</label>
-                <textarea class="ubcpi-field ubcpi-rationale" id="rationale" name="rationale" data-ng-model="rc.rationale" required ng-minlength="{{rationale_size.min}}" ng-maxlength="{{rationale_size.max}}"></textarea>
-                <p class="ubcpi-rationale-warning" ng-if="((rationale_size.max - rc.rationale.length) <= (rationale_size.max/10)) && (rc.rationale.length <= rationale_size.max)" translate>You are approaching the limit of {{rationale_size.max}} characters for this answer. Characters left: {{rationale_size.max - rc.rationale.length}}</p>
-                <p class="ubcpi-rationale-warning" ng-if="answerForm.rationale.$error.maxlength"><span class="ubcpi-show-incorrect"><strong translate>Error:</strong></span> <span translate>Please edit your explanation so that it is less than {{rationale_size.max}} characters.</span></p>
+                <div class="ubcpi-staff-button-wrapper" data-ng-if="user_role == 'instructor' || user_role == 'staff'" data-ng-init="rc.getStats()">
+                    <a data-ng-model="collapse" data-ng-click="collapse=!collapse" data-ng-class="{true: 'ubcpi-staff-statistics-button--active', false: 'ubcpi-staff-statistics-button'}[collapse]" translate>View Question Statistics</a>
+                    <div class="ubcpi-staff-statistics" data-ng-show="collapse">
 
-                <p class="ubc-pi-next">
-                    <span id="ubcpi-next-inline-hints">
-                        <span class="inline-hint" ng-if="rc.status() == rc.ALL_STATUS.NEW"><span class="sr">Hint</span><i aria-hidden="true" class="icon fa fa-info-circle"></i> <span translate>In the next step, you will be shown a selection of other responses that may help you refine your answer.</span></span>
-                    </span>
-                </p>
+                        <div class="ubcpi-breakdown-answer-options">
+                            <div class="ubcpi-option" data-ng-repeat="option in options track by $index">
+                                <label data-ng-class="{'ubcpi-show-correct ubcpi-answer': rc.correct_answer === $index, 'ubcpi-label ubcpi-answer': rc.correct_answer !== $index, 'ubcpi-no-pointer': !(rc.status() == rc.ALL_STATUS.NEW || rc.revising)}" for="original-option-input-{{ $index }}">
+                                    <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'above' && option.image_url" />
 
-                <div id="button-disabled-reason-label">
-                    <div class="message has-warnings warning-notice option-details-text" data-ng-if="answerForm.$invalid">
-                        <p role="alert" class="warning" id="button-disabled-reason">
-                            <span class="sr" translate>Warning</span>
-                            <i aria-hidden="true" class="icon fa fa-warning"></i>&nbsp;<span translate>Note:</span>
-                            <span ng-if="answerForm.rationale.$error.minlength" translate>Your rationale must be a minimum of {{rationale_size.min}} characters.</span>
-                            <span ng-if="answerForm.rationale.$error.maxlength" translate>Your rationale must be a maximum of {{rationale_size.max}} characters.</span>
-                            <span ng-if="answerForm.rationale.$invalid && answerForm.q.$valid" translate>In order to move to the next step please briefly explain why you chose this answer.</span>
-                            <span ng-if="answerForm.rationale.$valid && answerForm.q.$invalid" translate>In order to move to the next step please choose an answer.</span>
-                            <span ng-if="answerForm.q.$invalid && answerForm.rationale.$invalid" translate>In order to move to the next step, please choose an answer and briefly explain your choice.</span>
-                        </p>
+                                    <span data-ng-if="rc.correct_answer === $index" translate>Correct Answer:</span>
+                                    {{option.text}}
+
+                                    <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'below' && option.image_url" />
+                                </label>
+
+                                <div aria-hidden="true">
+                                    <pi-per-answer-chart options="options" stats="rc.stats" correct="rc.correct_answer" answers="{original: rc.answer_original, revised: rc.answer_revised}" per-answer-stats="$index" data-role="user_role"></pi-per-answer-chart>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
-                <div class="ubcpi-staff-button-wrapper" ng-if="user_role == 'instructor' || user_role == 'staff'" data-ng-init="rc.getStats()">
-                    <a ng-model="collapse" ng-click="collapse=!collapse" ng-class="{true: 'ubcpi-staff-statistics-button--active', false: 'ubcpi-staff-statistics-button'}[collapse]" translate>View Question Statistics</a>
-                    <div class="ubcpi-staff-statistics" ng-show="collapse">
-
-                        <div class="original-answers results-container choicegroup">
-                            <pi-barchart options="options" stats="rc.stats.original" correct="rc.correct_answer" data-role="user_role"></pi-barchart>
-                            <p class="ubcpi-chart-label">Original Answer</p>
-                        </div><!-- .original-answers -->
-
-                        <div class="revised-answers results-container choicegroup">
-                            <pi-barchart options="options" stats="rc.stats.revised" correct="rc.correct_answer" data-role="user_role"></pi-barchart>
-                            <p class="ubcpi-chart-label">Revised Answer</p>
-                        </div><!-- .revised-answers -->
-                        </div>
-                </div>
-
-                <input data-ng-disabled="answerForm.$invalid" type='button' class='ubcpi_submit' value="{{ 'Next Step' | translate }} &rarr;" name='ubcpi_next_step' data-ng-click="rc.clickSubmit($event);" aria-describedby="button-disabled-reason ubcpi-next-inline-hints" scroll-to-top-of-block='click' onclick=""/>
 
             </form>
 
@@ -139,24 +153,22 @@
         <div class="correct-revised-chart" data-ng-if="rc.status() == rc.ALL_STATUS.REVISED" data-ng-init="rc.getStats()">
 
             <h3 id="pi-question-h" class="question-text" style="display:inline;">{{display_name}}</h3>
-            <div class="question-weight" ng-if="rc.weight < 1"></div>
-
-            <div class="question-weight" ng-if="rc.weight == 1" translate>({{weight}} point possible)</div>
-
-            <div class="question-weight" ng-if="rc.weight > 1" translate>({{weight}} points possible)</div>
+            <div class="question-weight" data-ng-if="weight < 1"></div>
+            <div class="question-weight" data-ng-if="weight == 1" translate>({{weight}} point possible)</div>
+            <div class="question-weight" data-ng-if="weight > 1" translate>({{weight}} points possible)</div>
 
             <div style="padding: .5em; margin-bottom: 0px; margin-top: 10px; background: #ddd;"><h4 id="pi-question-h2" class="question-text" style="margin-bottom:0;color:#414141" translate>Question</h4></div>
             <div style="margin: 0 0 1.5em 0; padding: 1em; background: #f8f8f8;">
 
-            <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'above' && question_text.image_url" />
+            <img data-ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" data-ng-if="question_text.image_position == 'above' && question_text.image_url" />
 
-            <span aria-labelledby="pi-question-h" id="question-text" ng-bind-html="question_text.text" ng-if="question_text.text"></span>
+            <span aria-labelledby="pi-question-h" id="question-text" data-ng-bind-html="question_text.text" data-ng-if="question_text.text"></span>
 
-            <img ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" ng-if="question_text.image_position == 'below' && question_text.image_url" />
+            <img data-ng-src="{{question_text.image_url}}" id="question-image" alt="{{question_text.image_alt}}" data-ng-if="question_text.image_position == 'below' && question_text.image_url" />
             </div>
 
-            <div role="group" aria-label="Progress Indicator">
-                <span id="test" ng-if="rc.status() == rc.ALL_STATUS.REVISED">
+            <div id="finalReflecting" role="group" aria-label="Progress Indicator">
+                <span id="test" data-ng-if="rc.status() == rc.ALL_STATUS.REVISED">
                     <ol style="background:#f8f8f8;border:2px solid #ddd;margin:1em 0;padding-top:.3em;">
                         <li style="display:inline-block;width:30%;text-align:center;color:#414141;padding-top:.3em"><span class="fa fa-check-circle" aria-hidden="true" style="font-size:1.4em;"></span><br><span translate>Answer</span><span class="sr" translate>, Completed</span></li>
                             <li class="fa fa-angle-double-right" style="color:#ddd;vertical-align:15%;font-size:2.2em" aria-hidden="true"></li>
@@ -167,99 +179,49 @@
 
                 </span>
             </div>
+
             <section class="solution-span correct-answer-and-rationale" tabindex="-1" aria-labelledby="correct-option-heading" role="region">
 
                 <div class="detailed-solution" id="detailed-solution">
 
-                    <h5 id="correct-option-heading" ng-if="options.length > rc.correct_answer" translate>Correct Answer</h5>
-                    <h5 id="correct-option-heading" ng-if="!rc.correct_rationale.text"></h5>
-                    <h5 id="correct-option-heading" ng-if="options.length == rc.correct_answer && rc.correct_rationale.text" translate>Instructor's Explanation</h5>
+                    <legend>
+                        <span translate>Step 3) View Course-Wide Results</span>
+                        <p class="ubcpi-other-answers-instructions" translate>This is a look at how your classmates answered the question initially and after revision.</p>
+                        </span>
+                    </legend>
 
-                    <div id="correct-answer-choice" ng-if="options.length > rc.correct_answer">
-                        <img ng-src="{{options[rc.correct_answer].image_url}}" alt="{{options[rc.correct_answer].image_alt}}" ng-if="options[rc.correct_answer].image_position == 'above' && options[rc.correct_answer].image_url" />
+                    <span data-ng-if="rc.correct_answer === options.length && rc.correct_rationale.text" class="ubcpi-correct-answer-rationale">{{rc.correct_rationale.text}}</span>
 
-                        <p class="ubcpi-correct-answer-option ubcpi-show-correct" ng-if="options[rc.correct_answer].text">{{options[rc.correct_answer].text}}</p>
+                    <div class="ubcpi-breakdown-answer-options">
+                        <div class="ubcpi-option" data-ng-repeat="option in options track by $index">
+                            <label data-ng-class="{'ubcpi-show-correct ubcpi-answer': rc.correct_answer === $index, 'ubcpi-label ubcpi-answer': rc.correct_answer !== $index}" class="ubcpi-no-pointer" for="original-option-input-{{ $index }}">
+                                <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'above' && option.image_url" />
 
-                        <img ng-src="{{options[rc.correct_answer].image_url}}" alt="{{options[rc.correct_answer].image_alt}}" ng-if="options[rc.correct_answer].image_position == 'below' && options[rc.correct_answer].image_url" />
-                    </div>
+                                <span class="ubcpi-correct-answer-highlight" data-ng-if="rc.correct_answer === $index" translate>Correct Answer:</span>
+                                {{option.text}}
 
-                    <span class="ubcpi-correct-answer-rationale">{{rc.correct_rationale.text}}</span>
+                                <img data-ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" data-ng-if="option.image_position == 'below' && option.image_url" />
+                            </label>
 
-                    <div class="ubcpi-solution-your-answers" data-ng-model="rc.answer">
-                        <ul>
-                            <li class="ubcpi-initial">
-                                <p class="ubcpi-solution-your-initial-answer">
-                                    <span translate>Your initial answer:</span>
-                                    <span ng-if="rc.correct_answer === rc.answer_original" class="ubcpi-initial-option-text ubcpi-correct-final-answer ubcpi-show-correct">{{options[rc.answer_original].text}} </span>
-                                    <span ng-if="rc.correct_answer !== rc.answer_original && rc.correct_answer !== options.length" class="ubcpi-initial-option-text ubcpi-incorrect-final-answer ubcpi-show-incorrect">{{options[rc.answer_original].text}} </span>
-                                    <span ng-if="rc.correct_answer === options.length" class="ubcpi-initial-option-text ubcpi-correct-final-answer">{{options[rc.answer_original].text}} </span>
-                                    <span class="ubcpi-initial-option-num">({{'Option' | translate }} {{rc.answer_original + 1}})</span>
-                                </p>
-                                <span class="sr" translate>Student Rationale</span><i aria-hidden="true" class="icon fa fa-user"></i><span class="ubcpi-solution-your-initial-rationale ubcpi-solution-rationales">"{{rc.rationale_original}}"</span>
-                            </li>
-                            <li class="ubcpi-final">
+                            <span data-ng-if="rc.correct_answer === $index && rc.correct_rationale.text" class="ubcpi-correct-answer-rationale">{{rc.correct_rationale.text}}</span>
+
+                            <div aria-hidden="true">
+                                <pi-per-answer-chart options="options" stats="rc.stats" correct="rc.correct_answer" answers="{original: rc.answer_original, revised: rc.answer_revised}" per-answer-stats="$index" data-role="user_role"></pi-per-answer-chart>
+                            </div>
+
+                            <div data-ng-if="$index === rc.answer_revised" class="ubcpi-final">
                                 <p class="ubcpi-solution-your-final-answer">
-                                    <span translate>Your final answer:</span>
-                                    <span ng-if="rc.correct_answer === rc.answer_revised" class="ubcpi-initial-option-text ubcpi-correct-final-answer ubcpi-show-correct">{{options[rc.answer_revised].text}} </span>
-                                    <span ng-if="rc.correct_answer !== rc.answer_revised && rc.correct_answer !== options.length" class="ubcpi-initial-option-text ubcpi-incorrect-final-answer ubcpi-show-incorrect">{{options[rc.answer_revised].text}} </span>
-                                    <span ng-if="rc.correct_answer === options.length" class="ubcpi-initial-option-text ubcpi-correct-final-answer">{{options[rc.answer_revised].text}} </span>
-                                    <span class="ubcpi-initial-option-num">({{'Option' | translate }} {{rc.answer_revised + 1}})</span>
+                                    <span translate>Your final explanation:</span>
+                                    <span class="ubcpi-solution-rationales">"{{rc.rationale_revised}}"</span>
                                 </p>
-                                <span class="sr" translate>Student Rationale</span><i aria-hidden="true" class="icon fa fa-user"></i><span class="ubcpi-solution-your-final-rationale ubcpi-solution-rationales">"{{rc.rationale_revised}}"</span>
-                            </li>
-                        </ul>
-                        <p translate>See how your classmates answered <a href="#classbreakdown">below</a></p>
+                            </div>
 
+                        </div>
                     </div>
+
                 </div><!-- .detailed-solution -->
 
             </section><!-- .correct-answer-and-rationale -->
-
-            <div class="ubcpi-class-breakdown">
-
-                <a name="classbreakdown"></a>
-                <h5 translate>Class Breakdown</h5>
-                <p translate>This is a look at how your classmates answered the question during the initial and final rounds.</p>
-                <h6 translate>Answer Options</h6>
-                <div class="ubcpi-breakdown-answer-options">
-
-                    <p class="ubcpi-option" data-ng-repeat="option in options track by $index">
-                        <img ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" ng-if="option.image_position == 'above' && option.image_url" />
-
-                        <span class="ubcpi-breakdown-option-num"><i>Option {{$index + 1}}</i></span>&nbsp;<span class="ubcpi-breakdown-correct-option" ng-if="rc.correct_answer === $index" style="font-style:italic" translate>(correct)</span>
-                        <span ng-if="rc.correct_answer === $index" class="ubcpi-breakdown-answer-text ubcpi-show-correct">{{option.text}}</span>
-                        <span ng-if="rc.correct_answer === $index" class="sr">{{rc.calc($index)}}</span>
-                        <span ng-if="rc.correct_answer !== $index" class="ubcpi-breakdown-answer-text">{{option.text}}</span>
-                        <span ng-if="rc.correct_answer !== $index" class="sr">{{rc.calc($index)}}</span>
-
-                        <img ng-src="{{option.image_url}}" id="original-option-image-{{ $index }}" alt="{{option.image_alt}}" ng-if="option.image_position == 'below' && option.image_url" />
-
-                        <span class="chosen-option option-details-text" ng-if="rc.answer_original == $index && rc.status() == rc.ALL_STATUS.ANSWERED" translate>(You chose this option)</span>
-                    </p>
-
-                </div>
-
-                <div class="sr">
-                    <p class="ubcpi-option" data-ng-repeat="option in options track by $index">
-                        <li>
-                            <span class="ubcpi-breakdown-option-num" translate>Option {{$index + 1}}: {{rc.calc($index)}}</span>
-                            <span class="ubcpi-breakdown-correct-option" ng-if="rc.correct_answer === $index" translate> (correct)</span>
-                        </li>
-                </div>
-
-                <h6 translate>Initial Answer Selection</h6>
-                <div class="original-answers results-container choicegroup" aria-hidden="true">
-
-                    <pi-barchart options="options" stats="rc.stats.original" correct="rc.correct_answer" data-role="user_role"></pi-barchart>
-                </div><!-- .original-answers -->
-                <div ></div>
-
-                <h6 translate>Final Answer Selection</h6>
-                <div class="revised-answers results-container choicegroup" aria-hidden="true">
-                    <pi-barchart options="options" stats="rc.stats.revised" correct="rc.correct_answer" data-role="user_role"></pi-barchart>
-                </div><!-- .revised-answers -->
-
-            </div>
 
         </div><!-- .correct-revised-chart -->
 

--- a/ubcpi/static/html/ubcpi_edit.html
+++ b/ubcpi/static/html/ubcpi_edit.html
@@ -138,7 +138,7 @@
                     <div class="wrapper-comp-setting pi-wrapper-comp-setting">
                         <div class="pi-label-and-hint">
                             <label class="label setting-label pi-setting-label" for="pi-algo-num-responses" aria-describedby="pi-num-responses-tip" translate>Answers Students See - Number Selected <font color="red">*</font></label>
-                            <span id="pi-num-responses-tip" class="tip setting-help" translate>This is the number of examples shown to the students after they answer. Enter the # symbol to use the same number as the answer possibilities you've set.</span>
+                            <span id="pi-num-responses-tip" class="tip setting-help" translate>This is the number of examples shown on screen to the students after they answer. Students can choose to refresh for some other samples. Enter the # symbol to use the same number as the answer possibilities you've set.</span>
                         </div>
                         <input class="input setting-input pi-options" name="pi-algo-num-responses" id="pi-algo-num-responses" ng-model="esc.data.algo.num_responses" ng-model-options="{ debounce: 500 }" type="text" required />
                     </div>

--- a/ubcpi/static/js/spec/d3-pibar_spec.js
+++ b/ubcpi/static/js/spec/d3-pibar_spec.js
@@ -105,3 +105,96 @@ describe('D3 bar chart', function () {
     //    expect(line.empty()).not.toBe(true);
     //});
 });
+
+
+describe('D3 per answer chart', function () {
+    var chart;
+    var chartContainer;
+
+    describe('instructor view', function(){
+
+        beforeEach(function() {
+            var scope = {role:'instructor'};
+            chart = d3.custom.perAnswerChart(scope);
+            chartContainer = d3.select('body')
+                .append('div')
+                .attr('class', 'testContainer');
+        });
+
+        afterEach(function() {
+            // clean up
+            chartContainer.remove();
+        });
+
+        it('should provide getters and setters', function() {
+            var defaultChartWidth  = chart.width();
+            var defaultChartHeight = chart.height();
+            var defaultMinTotalFrequency = chart.minTotalFrequency();
+
+            chart.width(100)
+                .height(50)
+                .minTotalFrequency(20);
+
+            var newChartWidth  = chart.width();
+            var newChartHeight = chart.height();
+            var newMinTotalFrequency = chart.minTotalFrequency();
+
+
+            expect(defaultChartWidth).not.toBe(100);
+            expect(defaultChartHeight).not.toBe(50);
+            expect(defaultMinTotalFrequency).not.toBe(20);
+            expect(newChartWidth).toBe(100);
+            expect(newChartHeight).toBe(50);
+            expect(newMinTotalFrequency).toBe(20);
+        });
+
+
+        it('should have a minTotalFrequency of 1', function(){
+            var defaultMinTotalFrequency = chart.minTotalFrequency();
+            expect(defaultMinTotalFrequency).toBe(1);
+        });
+    });
+
+    describe('student view', function(){
+
+        beforeEach(function() {
+            var scope = {role:'student'};
+            chart = d3.custom.barChart(scope);
+            chartContainer = d3.select('body')
+                .append('div')
+                .attr('class', 'testContainer');
+        });
+
+        afterEach(function() {
+            // clean up
+            chartContainer.remove();
+        });
+
+        it('should provide getters and setters', function() {
+            var defaultChartWidth  = chart.width();
+            var defaultChartHeight = chart.height();
+            var defaultMinTotalFrequency = chart.minTotalFrequency();
+
+            chart.width(100)
+                .height(50)
+                .minTotalFrequency(20);
+
+            var newChartWidth  = chart.width();
+            var newChartHeight = chart.height();
+            var newMinTotalFrequency = chart.minTotalFrequency();
+
+
+            expect(defaultChartWidth).not.toBe(100);
+            expect(defaultChartHeight).not.toBe(50);
+            expect(defaultMinTotalFrequency).not.toBe(20);
+            expect(newChartWidth).toBe(100);
+            expect(newChartHeight).toBe(50);
+            expect(newMinTotalFrequency).toBe(20);
+        });
+
+        it('should have a minTotalFrequency of 10', function(){
+            var defaultMinTotalFrequency = chart.minTotalFrequency();
+            expect(defaultMinTotalFrequency).toBe(10);
+        });
+    });
+});

--- a/ubcpi/static/js/spec/ubcpi-barchar-directive_spec.js
+++ b/ubcpi/static/js/spec/ubcpi-barchar-directive_spec.js
@@ -115,4 +115,151 @@ describe('UBCPI', function () {
             })
         })
     });
+
+
+    describe('pi-per-answer-chart', function () {
+        var element, scope;
+
+        beforeEach(inject(function ($compile, $rootScope) {
+            scope = $rootScope;
+
+            element = angular.element(
+                '<pi-per-answer-chart options="options" stats="stats" answers="answers" correct="correct" per-answer-stats="per_answer_stats"></pi-per-answer-chart>'
+            );
+            $compile(element)(scope);
+            scope.$digest();
+        }));
+
+        it('should not render anything when stats is empty', function () {
+            expect(element.find('svg').length).toBe(0);
+            expect(element.find('g').length).toBe(0);
+        });
+
+        describe('directive', function () {
+            var options = [{
+                "text": "21",
+                "image_alt": "",
+                "image_url": "",
+                "image_position": "below",
+                "image_show_fields": 0
+            }, {
+                "text": "42",
+                "image_alt": "",
+                "image_url": "",
+                "image_position": "below",
+                "image_show_fields": 0
+            }, {
+                "text": "63",
+                "image_alt": "",
+                "image_url": "",
+                "image_position": "below",
+                "image_show_fields": 0
+            }];
+            var answers = {"original": 2, "revised": 1};
+            var correct = 0;
+
+            describe('with enough submissions', function() {
+                var stats = {
+                    "original": {0: 4, 1: 5, 2: 1},
+                    "revised": {0: 1, 1: 8, 2: 1},
+                };
+                beforeEach(function() {
+                    scope.$apply(function () {
+                        scope.options = options;
+                        scope.stats = stats;
+                        scope.answers = answers;
+                        scope.correct = correct;
+                        scope.per_answer_stats = 1;
+                    });
+                });
+
+                it('should render the template with given data', function() {
+                    // one graph for given answer per_answer_stats. two bars: one for initial choice, one for revision
+                    expect(element.find('> svg').length).toBe(1);
+                    expect(element.find('> svg > g').length).toBe(2);
+                });
+
+                it('should calculate percentage correctly for incorrect answer', function() {
+                    expect(element.find('> svg > g').eq(0).find('> rect').length).toBe(2);
+                    expect(
+                        element.find('> svg > g').eq(0).find('> rect.ubcpibar').attr('width') /
+                        element.find('> svg > g').eq(0).find('> rect:not(.ubcpibar)').attr('width')).toBe(0.5);
+                    expect(element.find('> svg > g').eq(0).find('> svg > text').text()).toContain('50%');
+                    expect(
+                        element.find('> svg > g').eq(1).find('> rect.ubcpibar').attr('width') /
+                        element.find('> svg > g').eq(1).find('> rect:not(.ubcpibar)').attr('width')).toBe(0.8);
+                    expect(element.find('> svg > g').eq(1).find('> svg > text').text()).toContain('80%');
+                });
+            });
+
+            describe('with enough submissions', function() {
+                var stats = {
+                    "original": {0: 4, 1: 5, 2: 1},
+                    "revised": {0: 1, 1: 8, 2: 1},
+                };
+                beforeEach(function() {
+                    scope.$apply(function () {
+                        scope.options = options;
+                        scope.stats = stats;
+                        scope.answers = answers;
+                        scope.correct = correct;
+                        scope.per_answer_stats = correct;
+                    });
+                });
+
+                it('should calculate percentage correctly for correct answer', function() {
+                    expect(element.find('> svg > g').eq(0).find('> rect').length).toBe(2);
+                    expect(
+                        element.find('> svg > g').eq(0).find('> rect.correct-answer').attr('width') /
+                        element.find('> svg > g').eq(0).find('> rect:not(.correct-answer)').attr('width')).toBe(0.4);
+                    expect(element.find('> svg > g').eq(0).find('> svg > text').text()).toContain('40%');
+                    expect(
+                        element.find('> svg > g').eq(1).find('> rect.correct-answer').attr('width') /
+                        element.find('> svg > g').eq(1).find('> rect:not(.correct-answer)').attr('width')).toBe(0.1);
+                    expect(element.find('> svg > g').eq(1).find('> svg > text').text()).toContain('10%');
+                });
+
+                it('should update when stats changed', function() {
+                    scope.$apply(function() {
+                        scope.stats = {
+                            "original": {0: 10, 1: 6, 2: 4},
+                            "revised": {0: 4, 1: 14, 2: 2},
+                        };
+                    });
+                    expect(element.find('> svg > g').eq(0).find('> rect').length).toBe(2);
+                    expect(
+                        element.find('> svg > g').eq(0).find('> rect.correct-answer').attr('width') /
+                        element.find('> svg > g').eq(0).find('> rect:not(.correct-answer)').attr('width')).toBe(0.5);
+                    expect(element.find('> svg > g').eq(0).find('> svg > text').text()).toContain('50%');
+                    expect(
+                        element.find('> svg > g').eq(1).find('> rect.correct-answer').attr('width') /
+                        element.find('> svg > g').eq(1).find('> rect:not(.correct-answer)').attr('width')).toBe(0.2);
+                    expect(element.find('> svg > g').eq(1).find('> svg > text').text()).toContain('20%');
+                });
+            });
+
+            describe('with enough submissions and showing stats for user\'s revision', function() {
+                var stats = {
+                    "original": {0: 4, 1: 5, 2: 1},
+                    "revised": {0: 1, 1: 8, 2: 1},
+                };
+                beforeEach(function() {
+                    scope.$apply(function () {
+                        scope.options = options;
+                        scope.stats = stats;
+                        scope.answers = answers;
+                        scope.correct = correct;
+                        scope.per_answer_stats = answers['revised'];
+                    });
+                });
+
+                it('should not indicate it as user\'s initial answer', function() {
+                    expect(element.find('> svg > g').eq(0).find('> svg > text').text()).not.toContain('including you');
+                });
+                it('should indicate it as user\'s revision', function() {
+                    expect(element.find('> svg > g').eq(1).find('> svg > text').text()).toContain('including you');
+                });
+            });
+        })
+    });
 });

--- a/ubcpi/static/js/spec/ubcpi_spec.js
+++ b/ubcpi/static/js/spec/ubcpi_spec.js
@@ -400,7 +400,6 @@ describe('UBCPI module', function () {
                 });
                 controller.getStats();
                 expect(controller.stats).toEqual(response);
-                expect(controller.calc(0)).toBe(" Initial Answer Selection: 100%  Final Answer Selection: 0%");
             });
 
             it('should call notify with error when backend errors', function() {

--- a/ubcpi/static/js/spec/ubcpi_spec.js
+++ b/ubcpi/static/js/spec/ubcpi_spec.js
@@ -41,6 +41,69 @@ describe('UBCPI module', function () {
         });
     });
 
+    describe('ubcpi-refresh-rationale directive', function() {
+        var $compile,
+            $rootScope,
+            backendService,
+            $httpBackend;
+
+        // Store references to $rootScope and $compile
+        // so they are available to all tests in this describe block
+        beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_) {
+            // The injector unwraps the underscores (_) from around the parameter names when matching
+            $compile = _$compile_;
+            $rootScope = _$rootScope_;
+            $httpBackend = _$httpBackend_;
+
+            mockConfig.urls.refresh_other_answers = '/handler/refresh_other_answers';
+        }));
+
+        afterEach(function() {
+            $httpBackend.verifyNoOutstandingExpectation();
+            $httpBackend.verifyNoOutstandingRequest();
+        });
+
+        it('should show button to refresh answers shown', function () {
+            var scope = $rootScope.$new(true);
+            scope.rc = {
+                other_answers: { answer: [] }
+            };
+            // Compile a piece of HTML containing the directive
+            var element = $compile("<div name=\"test_div\" class=\"ubcpi-refresh-option-button\" ubcpi-refresh-rationale ubcpi-option=\"1\" ubcpi-refresh-model=\"rc.other_answers.answers\"></div>")(scope);
+            scope.$digest();
+            expect(element.html()).toContain('Show other samples');
+        });
+
+        it('should allow refreshing of answers shown', function () {
+            var scope = $rootScope.$new(true);
+            scope.rc = {
+                other_answers: { answers: [] }
+            };
+            var param = {"option": "1"};
+            var exp = {
+                "other_answers": {
+                    "answers": [
+                        {"option": 0, "rationale": "Tree gets carbon from air."},
+                        {"option": 1, "rationale": "Tree gets minerals from soil."},
+                        {"option": 2, "rationale": "Tree drinks water."}]
+                },
+                "rationale_revised": null,
+                "answer_original": 1,
+                "rationale_original": "testing",
+                "answer_revised": null
+            };
+            var data = undefined;
+            $httpBackend.expectPOST('/handler/refresh_other_answers', JSON.stringify(param)).respond(200, exp);
+
+            // Compile a piece of HTML containing the directive
+            var element = $compile("<div name=\"test_div\" class=\"ubcpi-refresh-option-button\" ubcpi-refresh-rationale ubcpi-option=\"1\" ubcpi-refresh-model=\"rc.other_answers.answers\"></div>")(scope);
+            scope.$digest();
+            $(element).click();
+            $httpBackend.flush();
+            expect(scope.rc.other_answers).toEqual(exp.other_answers);
+        });
+    });
+
     describe('backendService', function() {
         var backendService, $httpBackend;
 
@@ -125,6 +188,38 @@ describe('UBCPI module', function () {
                 $httpBackend.flush();
 
                 expect(error).toBe('error');
+            });
+        });
+
+        describe('refresh_other_answers', function() {
+
+            beforeEach(function() {
+                mockConfig.urls.refresh_other_answers = '/handler/refresh_other_answers';
+            });
+
+            it('should be able to refresh other answers', function() {
+                var param = {"option": 1};
+                var exp = {
+                    "other_answers": {
+                        "answers": [
+                            {"option": 0, "rationale": "Tree gets carbon from air."},
+                            {"option": 1, "rationale": "Tree gets minerals from soil."},
+                            {"option": 2, "rationale": "Tree drinks water."}]
+                    },
+                    "rationale_revised": null,
+                    "answer_original": 1,
+                    "rationale_original": "testing",
+                    "answer_revised": null
+                };
+                var data = undefined;
+                $httpBackend.expectPOST('/handler/refresh_other_answers', JSON.stringify(param)).respond(200, exp);
+
+                backendService.refreshOtherAnswers(1).then(function(d) {
+                    data = d;
+                });
+                $httpBackend.flush();
+
+                expect(data).toEqual(exp);
             });
         });
 
@@ -450,8 +545,8 @@ describe('PeerInstructionXBlock function', function() {
     });
 
     it('should generate URLs using runtime', function() {
-        expect(mockRuntime.handlerUrl.calls.count()).toBe(4);
+        expect(mockRuntime.handlerUrl.calls.count()).toBe(5);
         expect(mockRuntime.handlerUrl.calls.allArgs()).toEqual(
-            [[mockElement, 'get_stats'], [mockElement, 'submit_answer'], [mockElement, 'get_asset'], [mockElement, 'get_data']]);
+            [[mockElement, 'get_stats'], [mockElement, 'submit_answer'], [mockElement, 'get_asset'], [mockElement, 'get_data'], [mockElement, 'refresh_other_answers']]);
     });
 });

--- a/ubcpi/static/js/src/d3-pibar.js
+++ b/ubcpi/static/js/src/d3-pibar.js
@@ -182,13 +182,14 @@ d3.custom.perAnswerChart = function(scope, gettext, allAnswerCount) {
             });
 
             if (totalFreq < minTotalFrequency) {
+                d3.select(this).selectAll("svg > *").remove();
                 d3.select(this)
                     .append("span")
                     .attr("id", 'not-enough-data')
                     .text(gettext("Not enough data to generate the chart. Please check back later."));
                 return;
             } else {
-                var notEnoughDataSpan = d3.select('#not-enough-data');
+                var notEnoughDataSpan = d3.select(this).select('#not-enough-data');
                 if (typeof notEnoughDataSpan !== 'undefined') {
                     notEnoughDataSpan.remove();
                 }

--- a/ubcpi/static/js/src/ubcpi-barchart-directive.js
+++ b/ubcpi/static/js/src/ubcpi-barchart-directive.js
@@ -37,3 +37,58 @@ angular.module('UBCPI').
             }
         }
     }]);
+
+
+angular.module('UBCPI').
+    directive('piPerAnswerChart', ['gettext', function(gettext){
+        return {
+            restrict: 'E',
+            scope: {
+                options: '=',
+                stats: '=',
+                correct: '=',
+                role: '=',
+                answers: '=',
+                perAnswerStats: '='
+            },
+            // no overwrite template
+            replace: false,
+            link: function(scope, element) {
+                // watch the stats as it could be async populated
+                scope.$watch('stats', function(stats) {
+                    if(!stats) {
+                        return;
+                    }
+
+                    var data = [];
+                    var allAnswerCount = 0;
+                    for (var k in stats) {
+                        var total = 0;
+                        for (var op in stats[k]) {
+                            total += stats[k][op];
+                        }
+                        if (total > allAnswerCount) {
+                            allAnswerCount = total;
+                        }
+                        data.push({
+                            percentage: (total > 0 && typeof stats[k][scope.perAnswerStats] !== 'undefined'?
+                                (stats[k][scope.perAnswerStats] / total) * 100 : 0),
+                            order: k === 'original'? 0 : 1,
+                            text:  (scope.answers[k] == scope.perAnswerStats? gettext('(including you) ') : ''),
+                            class: 'ubcpibar' +  (scope.correct == scope.perAnswerStats ? ' correct-answer' : '') +
+                                (k === 'original'? ' original' : ''),
+                            label_class: 'ubcpibar label',
+                            type: k === 'original'? gettext('Chose initially') : gettext('Chose after revision')
+                        });
+                    }
+
+                    d3.select(element[0]).select("svg").remove();   // remove old chart
+                    // generate the chart
+                    var chartLayout = d3.custom.perAnswerChart(scope, gettext, allAnswerCount);
+                    d3.select(element[0])
+                        .datum(data)
+                        .call(chartLayout);
+                }, true)
+            }
+        }
+    }]);

--- a/ubcpi/static/js/src/ubcpi.js
+++ b/ubcpi/static/js/src/ubcpi.js
@@ -151,6 +151,9 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
             // By default, we're not submitting, this changes when someone presses the submit button
             self.submitting = false;
 
+            // Whether user is revising the answer
+            self.revising = false;
+
             /**
              * Determine if the submit button should be disabled
              * If we have an answer selected, a rationale that is large
@@ -191,6 +194,14 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
             self.getStats = function () {
                 return backendService.getStats().then(function(data) {
                     self.stats = data;
+
+                    self.perAnswerStats = {};
+                    for (var i = 0; i < $scope.options.length; i++) {
+                        self.perAnswerStats[i] = {
+                            'original': (typeof self.stats.original[i] !== 'undefined'? self.stats.original[i] : 0),
+                            'revised' : (typeof self.stats.revised[i] !== 'undefined'? self.stats.revised[i] : 0)
+                        }
+                    }
                 }, function(error) {
                     notify('error', {
                         'title': gettext('Error retrieving statistics!'),
@@ -198,34 +209,6 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                     });
                     return $q.reject(error);
                 });
-            };
-
-            self.calc = function(s) {
-                var originalPercentage = gettext(" Initial Answer Selection: ");
-                var revisedPercentage = gettext(" Final Answer Selection: ");
-                if (typeof self.stats !== 'undefined' && typeof s !== 'undefined' && typeof self.stats.original[s] !== 'undefined') {
-                    var totalCounts = 0;
-                    for (var i = 0; i < data.options.length; i++) {
-                        if (typeof self.stats.original[i] !== 'undefined')
-                            totalCounts += self.stats.original[i];
-                    }
-                    originalPercentage += self.stats.original[s] / totalCounts * 100 + "%";
-                }
-                else
-                    originalPercentage += "0%";
-
-                if (typeof self.stats !== 'undefined' && typeof s !== 'undefined' && typeof self.stats.revised[s] !== 'undefined') {
-                    var totalCounts = 0;
-                    for (var i = 0; i < data.options.length; i++) {
-                        if (typeof self.stats.revised[i] !== 'undefined')
-                            totalCounts += self.stats.revised[i];
-                    }
-                    revisedPercentage += self.stats.revised[s] / totalCounts * 100 + "%";
-                }
-                else
-                    revisedPercentage += "0%";
-
-                return originalPercentage + " " + revisedPercentage;
             };
 
             function get_data() {
@@ -257,6 +240,14 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                 self.options = data.options;
             }
 
+            self.hasSampleExplanationForOption = function (option) {
+                for (var index in self.other_answers.answers) {
+                    if (option == self.other_answers.answers[index].option) {
+                        return true;
+                    }
+                }
+                return false;
+            };
         }]);
 
 /**

--- a/ubcpi/static/js/src/ubcpi.js
+++ b/ubcpi/static/js/src/ubcpi.js
@@ -69,17 +69,78 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                     if (!target) {
                         target = ele;
                     }
-                    $('html,body').animate({scrollTop: target.offset().top}, "slow");
+                    if (target && target.offset()) {
+                        $('html,body').animate({scrollTop: target.offset().top}, "slow");
+                    }
                 });
             }
         };
     })
+
+    /**
+     * Scroll to the xblock progress bar
+     */
+    .directive('scrollToProgressBar', function() {
+        return {
+            restrict: 'A',
+            scope: {
+                scrollToProgressBar: '@'
+            },
+            link: function(scope, ele, attr, ctrl) {
+                ele.on(scope.scrollToProgressBar? scope.scrollToProgressBar : 'click', function() {
+                    var target;
+                    target = ele.parents('.ubcpi_block').find('.ubcpi_progress_bar');
+                    if (!target) {
+                        target = ele;
+                    }
+                    if (target && target.offset()) {
+                        $('html,body').animate({scrollTop: target.offset().top}, "slow");
+                    }
+                });
+            }
+        };
+    })
+
+    .directive('ubcpiRefreshRationale', ['backendService', 'notify', 'gettext', function(backendService, notify, gettext) {
+        return {
+            retrict: 'A',
+            replace: false,
+            scope: {
+                ubcpiRefreshModel: '=',
+            },
+            link: function(scope, ele, attr, ctrl) {
+                var option = attr.ubcpiOption;
+                var desc = '<span>' + gettext('Show other samples') + '</span>';
+                var desc_loading = '<span>' + gettext('Refreshing...') + '</span>';
+
+                function call_refresh() {
+                    ele.empty().append('<i class="icon fa fa-refresh fa-spin" aria-hidden="true"></i> ' + desc_loading);
+                    backendService.refreshOtherAnswers(option).then(function(data) {
+                        if (data && data.other_answers && data.other_answers.answers) {
+                            scope.ubcpiRefreshModel = data.other_answers.answers
+                        }
+                    }, function(error) {
+                        notify('error', {
+                            'title': gettext('Error refreshing answers from other students'),
+                            'message': gettext('Please refresh the page and try again!')
+                        });
+                    }).finally(function() {
+                        ele.empty().append('<i aria-hidden="true" class="icon fa fa-refresh"></i> ' + desc);
+                    });
+                }
+
+                ele.on('click', call_refresh);
+                ele.empty().append('<i aria-hidden="true" class="icon fa fa-refresh"></i> ' + desc);
+            }
+        }
+    }])
 
     .factory('backendService', ['$http', '$q', '$rootScope', function ($http, $q, $rootScope) {
         return {
             getStats: getStats,
             submit: submit,
             get_data: get_data,
+            refreshOtherAnswers: refreshOtherAnswers,
         };
 
         function getStats() {
@@ -113,6 +174,21 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
         function get_data() {
             var dataUrl = $rootScope.config.urls.get_data;
             return $http.post(dataUrl, '""').then(
+                function(response) {
+                    return response.data;
+                },
+                function(error) {
+                    return $q.reject(error);
+                }
+            );
+        }
+
+        function refreshOtherAnswers(option) {
+            var refreshUrl = $rootScope.config.urls.refresh_other_answers;
+            var refreshParam = JSON.stringify({
+                "option": option,
+            });
+            return $http.post(refreshUrl, refreshParam).then(
                 function(response) {
                     return response.data;
                 },
@@ -238,6 +314,7 @@ angular.module('UBCPI', ['ngSanitize', 'ngCookies', 'gettext'])
                 self.rationale = data.rationale_revised || data.rationale_original;
                 self.weight = data.weight;
                 self.options = data.options;
+                self.alt_answers_available = data.alt_answers_available;
             }
 
             self.hasSampleExplanationForOption = function (option) {
@@ -270,7 +347,8 @@ function PeerInstructionXBlock(runtime, element, data) {
         'get_stats': runtime.handlerUrl(element, 'get_stats'),
         'submit_answer': runtime.handlerUrl(element, 'submit_answer'),
         'get_asset': runtime.handlerUrl(element, 'get_asset'),
-        'get_data': runtime.handlerUrl(element, 'get_data')
+        'get_data': runtime.handlerUrl(element, 'get_data'),
+        'refresh_other_answers': runtime.handlerUrl(element, 'refresh_other_answers'),
     };
 
     // in order to support multiple same apps on the same page but

--- a/ubcpi/test/data/refresh_other_answers.json
+++ b/ubcpi/test/data/refresh_other_answers.json
@@ -1,0 +1,35 @@
+{
+  "valid": {
+    "submit_answer_param": {
+      "q": 0,
+      "rationale": "This is my answer.",
+      "status": 0
+    },
+    "refresh_params": {
+      "option": "2"
+    },
+    "expect": {
+      "other_answers": {
+        "answers": [
+          {
+            "option": 0,
+            "rationale": "This is answer shown for option 0"
+          },
+          {
+            "option": 1,
+            "rationale": "This is answer shown for option 1"
+          },
+          {
+            "option": 2,
+            "rationale": "This is answer shown for option 2"
+          }
+        ]
+      },
+      "answer_original": 0,
+      "rationale_original": "This is my answer.",
+      "answer_revised": null,
+      "rationale_revised": null,
+      "alt_answers_available": {"1": false, "0": true, "2": false}
+    }
+  }
+}

--- a/ubcpi/test/data/submit_answer.json
+++ b/ubcpi/test/data/submit_answer.json
@@ -25,7 +25,8 @@
       "answer_original": 0,
       "rationale_original": "This is my answer.",
       "answer_revised": null,
-      "rationale_revised": null
+      "rationale_revised": null,
+      "alt_answers_available": {"1": false, "0": true, "2": false}
     },
     "post2": {
       "q": 1,

--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -618,7 +618,13 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
             "rationale_revised": answers.get_rationale(1),
         }
         if answers.has_revision(0) and not answers.has_revision(1):
-            ret['other_answers'] = other_answers
+            # If no persisted peer answers, generate new ones.
+            # Could happen if a student completed Step 1 before ubcpi upgraded to persist peer answers.
+            if not self.other_answers_shown:
+                ret['other_answers'] = get_other_answers(
+                    self.sys_selected_answers, self.seeds, self.get_student_item_dict, self.algo, self.options)
+            else:
+                ret['other_answers'] = other_answers
 
         # reveal the correct answer in the end
         if answers.has_revision(1):


### PR DESCRIPTION
UI revision:
- Revise UI to improve visual consistency
- Fix problem of response missing when switching between units
- Add test cases for new chart format
- Generate and return peer answers on-the-fly if nothing persisted

Closes #144
Closes #148

Fix issues with deleting learner state:
- implement the callback clear_student_state
- add a new submission to indicate existing answers are deleted
- add (but commented out) code to partially support revising score manually. But full support will require adding logic to persist the score within xblock
- fix issue with same explanation displayed multiple times in Step 2
- simplify the Simple algo for picking sample explanation. Instead of using arbitrary max loop count of 100 and hope to pick unique explanations, remove item from the pool once they are chosen.

Closes #119
Closes #149

Allow students to fresh rationales shown
- on step 2, display a link to allow students to refresh the answers shown

Closes #165